### PR TITLE
Trim string values on deserialize

### DIFF
--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -3,10 +3,10 @@ import re
 import sys
 
 from .bake import bake_schema, get_field_for
-from .metadata import datetime_metadata, decimal_metadata, metadata
+from .metadata import datetime_metadata, decimal_metadata, metadata, str_metadata
 from .missing import MISSING
 from .naming_case import CAMEL_CASE, CAPITAL_CAMEL_CASE, DEFAULT_CASE, CamelCase, CapitalCamelCase, NamingCase
-from .options import NoneValueHandling, options
+from .options import NoneValueHandling, StringValueSanitizing, options
 from .serialization import EmptySchema, dump, dump_many, load, load_many, schema
 
 __all__: tuple[str, ...] = (
@@ -18,6 +18,7 @@ __all__: tuple[str, ...] = (
     "get_field_for",
     "options",
     "NoneValueHandling",
+    "StringValueSanitizing",
     "MISSING",
     "NamingCase",
     "DEFAULT_CASE",
@@ -28,6 +29,7 @@ __all__: tuple[str, ...] = (
     "schema",
     "EmptySchema",
     "metadata",
+    "str_metadata",
     "decimal_metadata",
     "datetime_metadata",
 )

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -26,7 +26,7 @@ from .fields import (
     uuid_field,
 )
 from .naming_case import NamingCase
-from .options import NoneValueHandling, get_options_for
+from .options import NoneValueHandling, get_options_for, StringValueSanitizing
 
 _T = TypeVar("_T")
 _MARSHMALLOW_VERSION_MAJOR = int(m.__version__.split(".")[0])
@@ -36,6 +36,7 @@ def bake_schema(
     cls: Type[_T],
     *,
     naming_case: NamingCase | None = None,
+    string_value_sanitizing: StringValueSanitizing | None = None,
 ) -> Type[m.Schema]:
     if not dataclasses.is_dataclass(cls):
         raise ValueError(f"{cls} is not a dataclass")
@@ -43,6 +44,9 @@ def bake_schema(
     options = get_options_for(cls)
     if naming_case is None:
         naming_case = options.naming_case
+
+    if string_value_sanitizing is None:
+        string_value_sanitizing = options.string_value_sanitizing
 
     fields = dataclasses.fields(cls)
     schema_class = type(

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -18,7 +18,7 @@ def str_field(
     **_: Any,
 ) -> m.fields.Field:
     if default is m.missing:
-        return m.fields.Str(
+        return StringField(
             allow_none=not required,
             validate=validate,
             **default_fields(m.missing),
@@ -29,9 +29,9 @@ def str_field(
         if default is None:
             raise ValueError("Default value cannot be none")
 
-        return m.fields.String(required=True, validate=validate, **data_key_fields(name))
+        return StringField(required=True, validate=validate, **data_key_fields(name))
 
-    return m.fields.Str(
+    return StringField(
         allow_none=True,
         validate=validate,
         **default_fields(None if default is dataclasses.MISSING else default),
@@ -405,6 +405,17 @@ def raw_field(
 
 DateTimeField: Type[m.fields.DateTime]
 EnumField: Type[m.fields.String]
+
+
+class StringField(m.fields.String):
+    def _deserialize(self, value: Any, attr: Any, data: Any, **kwargs: Any) -> Any:
+        result = super()._deserialize(value, attr, data, **kwargs)
+        if result is not None:
+            result = value.strip()
+        if self.allow_none and result == "":
+            result = None
+        return result
+
 
 if _MARSHMALLOW_VERSION_MAJOR >= 3:
 

--- a/marshmallow_recipe/metadata.py
+++ b/marshmallow_recipe/metadata.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Mapping
 
 from .missing import MISSING
+from .options import StringValueSanitizing
 
 
 def metadata(
@@ -13,6 +14,22 @@ def metadata(
         result.update(name=name)
     if validate is not None:
         result.update(validate=validate)
+    return result
+
+
+def str_metadata(
+    *,
+    name: str = MISSING,
+    validate: Callable[[Any], Any] | None = None,
+    string_value_sanitizing: StringValueSanitizing = MISSING,
+) -> Mapping[str, Any]:
+    result: dict[str, Any] = {}
+    if name is not MISSING:
+        result.update(name=name)
+    if validate is not None:
+        result.update(validate=validate)
+    if string_value_sanitizing is not MISSING:
+        result.update(string_value_sanitizing=string_value_sanitizing)
     return result
 
 

--- a/marshmallow_recipe/options.py
+++ b/marshmallow_recipe/options.py
@@ -15,14 +15,24 @@ class NoneValueHandling(str, enum.Enum):
         return self.value
 
 
+class StringValueSanitizing(str, enum.Enum):
+    DISABLED = "DISABLED"
+    STRIP = "STRIP"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 @dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class DataclassOptions:
     none_value_handling: NoneValueHandling
+    string_value_sanitizing: StringValueSanitizing
     naming_case: NamingCase
 
 
 _DEFAULT_OPTIONS = DataclassOptions(
     none_value_handling=NoneValueHandling.IGNORE,
+    string_value_sanitizing=StringValueSanitizing.DISABLED,
     naming_case=DEFAULT_CASE,
 )
 
@@ -30,6 +40,7 @@ _DEFAULT_OPTIONS = DataclassOptions(
 def options(
     *,
     none_value_handling: NoneValueHandling = _DEFAULT_OPTIONS.none_value_handling,
+    string_value_sanitizing: StringValueSanitizing = _DEFAULT_OPTIONS.string_value_sanitizing,
     naming_case: NamingCase = _DEFAULT_OPTIONS.naming_case,
 ):
     def wrap(cls: Any):
@@ -38,6 +49,7 @@ def options(
             _OPTIONS,
             DataclassOptions(
                 none_value_handling=none_value_handling,
+                string_value_sanitizing=string_value_sanitizing,
                 naming_case=naming_case,
             ),
         )

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -85,19 +85,19 @@ EMPTY_SCHEMA = m.Schema()
             m.fields.Bool(allow_none=True, **default_fields(None), **data_key_fields("i")),
         ),
         # simple types: str
-        (str, {}, m.fields.Str(required=True)),
-        (Optional[str], {}, m.fields.Str(allow_none=True, **default_fields(None))),
-        (str | None, {}, m.fields.Str(allow_none=True, **default_fields(None))),
-        (str, mr.metadata(name="i"), m.fields.Str(required=True, **data_key_fields("i"))),
+        (str, {}, mr.fields.StringField(required=True)),
+        (Optional[str], {}, mr.fields.StringField(allow_none=True, **default_fields(None))),
+        (str | None, {}, mr.fields.StringField(allow_none=True, **default_fields(None))),
+        (str, mr.metadata(name="i"), mr.fields.StringField(required=True, **data_key_fields("i"))),
         (
             Optional[str],
             mr.metadata(name="i"),
-            m.fields.Str(allow_none=True, **default_fields(None), **data_key_fields("i")),
+            mr.fields.StringField(allow_none=True, **default_fields(None), **data_key_fields("i")),
         ),
         (
             str | None,
             mr.metadata(name="i"),
-            m.fields.Str(allow_none=True, **default_fields(None), **data_key_fields("i")),
+            mr.fields.StringField(allow_none=True, **default_fields(None), **data_key_fields("i")),
         ),
         # simple types: int
         (int, {}, m.fields.Int(required=True)),

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -64,11 +64,11 @@ EMPTY_SCHEMA = m.Schema()
 
 
 @pytest.mark.parametrize(
-    "type, metadata, field",
+    "type, metadata, default_string_value_sanitizing, field",
     [
         # Any
-        (Any, {}, m.fields.Raw(allow_none=True, **default_fields(None))),
-        (Any, mr.metadata(name="i"), m.fields.Raw(allow_none=True, **default_fields(None), **data_key_fields("i"))),
+        (Any, {}, mr.StringValueSanitizing.DISABLED, m.fields.Raw(allow_none=True, **default_fields(None))),
+        (Any, mr.metadata(name="i"), mr.StringValueSanitizing.DISABLED, m.fields.Raw(allow_none=True, **default_fields(None), **data_key_fields("i"))),
         # simple types: bool
         (bool, {}, m.fields.Bool(required=True)),
         (Optional[bool], {}, m.fields.Bool(allow_none=True, **default_fields(None))),
@@ -407,7 +407,8 @@ EMPTY_SCHEMA = m.Schema()
         ),
     ],
 )
-def test_get_field_for(type: type, metadata: dict[str, Any], field: m.fields.Field) -> None:
+def test_get_field_for(type: type, metadata: dict[str, Any], default_string_value_sanitizing: mr.StringValueSanitizing,
+                       field: m.fields.Field) -> None:
     with unittest.mock.patch("marshmallow_recipe.bake.bake_schema") as bake_schema:
         bake_schema.return_value = EMPTY_SCHEMA
-        assert_fields_equal(mr.get_field_for(type, metadata, naming_case=mr.DEFAULT_CASE), field)
+        assert_fields_equal(mr.get_field_for(type, metadata, naming_case=mr.DEFAULT_CASE, string_value_sanitizing=default_string_value_sanitizing), field)

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -85,19 +85,54 @@ EMPTY_SCHEMA = m.Schema()
             m.fields.Bool(allow_none=True, **default_fields(None), **data_key_fields("i")),
         ),
         # simple types: str
-        (str, {}, mr.fields.StringField(required=True)),
-        (Optional[str], {}, mr.fields.StringField(allow_none=True, **default_fields(None))),
-        (str | None, {}, mr.fields.StringField(allow_none=True, **default_fields(None))),
-        (str, mr.metadata(name="i"), mr.fields.StringField(required=True, **data_key_fields("i"))),
+        (str, {}, mr.fields.StringField(required=True, string_value_sanitizing=mr.StringValueSanitizing.DISABLED)),
         (
             Optional[str],
-            mr.metadata(name="i"),
-            mr.fields.StringField(allow_none=True, **default_fields(None), **data_key_fields("i")),
+            {},
+            mr.fields.StringField(
+                allow_none=True, string_value_sanitizing=mr.StringValueSanitizing.DISABLED, **default_fields(None)
+            ),
+        ),
+        (
+            str | None,
+            {},
+            mr.fields.StringField(
+                allow_none=True, string_value_sanitizing=mr.StringValueSanitizing.DISABLED, **default_fields(None)
+            ),
+        ),
+        (
+            str,
+            mr.str_metadata(string_value_sanitizing=mr.StringValueSanitizing.STRIP),
+            mr.fields.StringField(
+                required=True, string_value_sanitizing=mr.StringValueSanitizing.STRIP, **data_key_fields(None)
+            ),
+        ),
+        (
+            str,
+            mr.str_metadata(name="i"),
+            mr.fields.StringField(
+                required=True, string_value_sanitizing=mr.StringValueSanitizing.DISABLED, **data_key_fields("i")
+            ),
+        ),
+        (
+            Optional[str],
+            mr.str_metadata(name="i"),
+            mr.fields.StringField(
+                allow_none=True,
+                string_value_sanitizing=mr.StringValueSanitizing.DISABLED,
+                **default_fields(None),
+                **data_key_fields("i"),
+            ),
         ),
         (
             str | None,
             mr.metadata(name="i"),
-            mr.fields.StringField(allow_none=True, **default_fields(None), **data_key_fields("i")),
+            mr.fields.StringField(
+                allow_none=True,
+                string_value_sanitizing=mr.StringValueSanitizing.DISABLED,
+                **default_fields(None),
+                **data_key_fields("i"),
+            ),
         ),
         # simple types: int
         (int, {}, m.fields.Int(required=True)),

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -362,13 +362,14 @@ def test_naming_case_in_options() -> None:
         ("   \t \r \n   ", ""),
     ],
 )
-def test_deserialize_string_trims_value(dumped_value: str, loaded_value: str) -> None:
+def test_deserialize_string_strips_value(dumped_value: str, loaded_value: str) -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-    @mr.options(naming_case=mr.CAMEL_CASE)
     class TestFieldContainer:
-        test_field: str
+        test_field: str = dataclasses.field(
+            metadata=mr.str_metadata(string_value_sanitizing=mr.StringValueSanitizing.STRIP)
+        )
 
-    loaded = mr.load(TestFieldContainer, {"testField": dumped_value})
+    loaded = mr.load(TestFieldContainer, {"test_field": dumped_value})
     assert loaded == TestFieldContainer(test_field=loaded_value)
 
 
@@ -383,9 +384,47 @@ def test_deserialize_string_trims_value(dumped_value: str, loaded_value: str) ->
 )
 def test_deserialize_optional_string_trims_value(dumped_value: str | None, loaded_value: str | None) -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-    @mr.options(naming_case=mr.CAMEL_CASE)
+    class TestFieldContainer:
+        test_field: str | None = dataclasses.field(
+            metadata=mr.str_metadata(string_value_sanitizing=mr.StringValueSanitizing.STRIP)
+        )
+
+    loaded = mr.load(TestFieldContainer, {"test_field": dumped_value})
+    assert loaded == TestFieldContainer(test_field=loaded_value)
+
+
+@pytest.mark.parametrize(
+    "dumped_value, loaded_value",
+    [
+        ("  \t   \r\n  some_value  \t   \n \r  ", "some_value"),
+        ("", ""),
+        ("   \t \r \n   ", ""),
+    ],
+)
+def test_deserialize_string_strips_value_options(dumped_value: str, loaded_value: str) -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    @mr.options(string_value_sanitizing=mr.StringValueSanitizing.STRIP)
+    class TestFieldContainer:
+        test_field: str
+
+    loaded = mr.load(TestFieldContainer, {"test_field": dumped_value})
+    assert loaded == TestFieldContainer(test_field=loaded_value)
+
+
+@pytest.mark.parametrize(
+    "dumped_value, loaded_value",
+    [
+        ("  \t   \r\n  some_value  \t   \n \r  ", "some_value"),
+        ("", None),
+        ("   \t \r \n   ", None),
+        (None, None),
+    ],
+)
+def test_deserialize_optional_string_trims_value_options(dumped_value: str | None, loaded_value: str | None) -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    @mr.options(string_value_sanitizing=mr.StringValueSanitizing.STRIP)
     class TestFieldContainer:
         test_field: str | None
 
-    loaded = mr.load(TestFieldContainer, {"testField": dumped_value})
+    loaded = mr.load(TestFieldContainer, {"test_field": dumped_value})
     assert loaded == TestFieldContainer(test_field=loaded_value)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -352,3 +352,38 @@ def test_naming_case_in_options() -> None:
 
     dumped = mr.dump(TestFieldContainer(test_field="some_value"))
     assert dumped == {"testField": "some_value"}
+
+
+@pytest.mark.parametrize(
+    "dumped_value, loaded_value",
+    [
+        ("  \t   \r\n  some_value  \t   \n \r  ", "some_value"),
+        ("", ""),
+    ],
+)
+def test_deserialize_string_trims_value(dumped_value: str, loaded_value: str) -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    @mr.options(naming_case=mr.CAMEL_CASE)
+    class TestFieldContainer:
+        test_field: str
+
+    loaded = mr.load(TestFieldContainer, {"testField": dumped_value})
+    assert loaded == TestFieldContainer(test_field=loaded_value)
+
+
+@pytest.mark.parametrize(
+    "dumped_value, loaded_value",
+    [
+        ("  \t   \r\n  some_value  \t   \n \r  ", "some_value"),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_deserialize_optional_string_trims_value(dumped_value: str | None, loaded_value: str | None) -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    @mr.options(naming_case=mr.CAMEL_CASE)
+    class TestFieldContainer:
+        test_field: str | None
+
+    loaded = mr.load(TestFieldContainer, {"testField": dumped_value})
+    assert loaded == TestFieldContainer(test_field=loaded_value)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -359,6 +359,7 @@ def test_naming_case_in_options() -> None:
     [
         ("  \t   \r\n  some_value  \t   \n \r  ", "some_value"),
         ("", ""),
+        ("   \t \r \n   ", ""),
     ],
 )
 def test_deserialize_string_trims_value(dumped_value: str, loaded_value: str) -> None:
@@ -376,6 +377,7 @@ def test_deserialize_string_trims_value(dumped_value: str, loaded_value: str) ->
     [
         ("  \t   \r\n  some_value  \t   \n \r  ", "some_value"),
         ("", None),
+        ("   \t \r \n   ", None),
         (None, None),
     ],
 )


### PR DESCRIPTION
```python
@dataclass
class Test:
  field: str

assert mr.load(Test, {"field": "  value  "}) == Test(field="value")
assert mr.load(Test, {"field": ""}) == Test(field="")
assert mr.load(Test, {"field": "   "}) == Test(field="")
mr.load(Test, {"field": None})  # error

@dataclass
class Test2:
  field: str | None

assert mr.load(Test2, {"field": "  value  "}) == Test2(field="value")
assert mr.load(Test2, {"field": ""}) == Test2(field=None)
assert mr.load(Test2, {"field": "   "}) == Test2(field=None)
assert mr.load(Test2, {"field": None}) == Test2(field=None)
```