### PR TITLE
Add pre_load hooks

### DIFF
--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -3,6 +3,7 @@ import re
 import sys
 
 from .bake import bake_schema, get_field_for
+from .hooks import add_pre_load, pre_load
 from .metadata import datetime_metadata, decimal_metadata, metadata
 from .missing import MISSING
 from .naming_case import CAMEL_CASE, CAPITAL_CAMEL_CASE, DEFAULT_CASE, CamelCase, CapitalCamelCase, NamingCase
@@ -30,6 +31,8 @@ __all__: tuple[str, ...] = (
     "metadata",
     "decimal_metadata",
     "datetime_metadata",
+    "pre_load",
+    "add_pre_load",
 )
 
 __version__ = "0.0.12"

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -25,6 +25,7 @@ from .fields import (
     str_field,
     uuid_field,
 )
+from .hooks import get_pre_loads
 from .naming_case import NamingCase
 from .options import NoneValueHandling, get_options_for
 
@@ -137,6 +138,13 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
             def post_load(self, data: dict[str, Any], **_: Any) -> Any:
                 return cls(**data)
 
+            @m.pre_load
+            def pre_load(self, data: dict[str, Any], **_: Any) -> Any:
+                result = data
+                for pre_load in get_pre_loads(cls):
+                    result = pre_load(result)
+                return result
+
         return _Schema
 
 else:
@@ -152,6 +160,13 @@ else:
             @m.post_load  # type: ignore
             def post_load(self, data: dict[str, Any]) -> Any:
                 return cls(**data)
+
+            @m.pre_load  # type: ignore
+            def pre_load(self, data: dict[str, Any]) -> Any:
+                result = data
+                for pre_load in get_pre_loads(cls):
+                    result = pre_load(result)
+                return result
 
         return _Schema
 

--- a/marshmallow_recipe/hooks.py
+++ b/marshmallow_recipe/hooks.py
@@ -1,0 +1,27 @@
+import inspect
+from typing import Any, Callable, Type
+
+_PRE_LOAD = "__marshmallow_recipe_pre_load_"
+_PRE_LOAD_CLASS_ = "__marshmallow_recipe_pre_load_class_"
+
+
+def pre_load(fn: Callable[..., Any]) -> Callable[..., Any]:
+    setattr(fn, _PRE_LOAD, True)
+    return fn
+
+
+def get_pre_loads(cls: Type) -> list[Callable[..., Any]]:
+    result = []
+    for _, method in inspect.getmembers(cls):
+        if hasattr(method, _PRE_LOAD):
+            result.append(method)
+    for fn in getattr(cls, _PRE_LOAD_CLASS_, []):
+        result.append(fn)
+    return result
+
+
+def add_pre_load(cls: Type, fn: Callable[[dict[str, Any]], dict[str, Any]]) -> None:
+    if not hasattr(cls, _PRE_LOAD_CLASS_):
+        setattr(cls, _PRE_LOAD_CLASS_, [])
+    pre_loads: list = getattr(cls, _PRE_LOAD_CLASS_)
+    pre_loads.append(fn)

--- a/tests/test_pre_load.py
+++ b/tests/test_pre_load.py
@@ -1,0 +1,76 @@
+import dataclasses
+from typing import Any
+from unittest.mock import ANY
+
+import marshmallow_recipe as mr
+from marshmallow_recipe.hooks import add_pre_load, get_pre_loads
+
+
+def test_get_pre_loads() -> None:
+    @dataclasses.dataclass
+    class MyClass:
+        x: int
+
+        @staticmethod
+        @mr.pre_load
+        def pre_load(data: dict[str, Any]) -> dict[str, Any]:
+            data["test"] = "value"
+            return data
+
+        @classmethod
+        @mr.pre_load
+        def pre_load2(cls, data: dict[str, Any]) -> dict[str, Any]:
+            assert cls is MyClass
+            data["test"] = "value"
+            return data
+
+    add_pre_load(MyClass, lambda data: {**data, "test": "value"})
+
+    a = get_pre_loads(MyClass)
+    assert a == [MyClass.pre_load, MyClass.pre_load2, ANY]
+    assert a[0]({}) == {"test": "value"}
+    assert a[1]({}) == {"test": "value"}
+    assert a[2]({}) == {"test": "value"}
+
+
+def test_deserialize_with_pre_load() -> None:
+    @dataclasses.dataclass
+    class MyClass:
+        x: str
+
+        @staticmethod
+        @mr.pre_load
+        def pre_load1(data: dict[str, Any]) -> dict[str, Any]:
+            data["x"] = data["x"] + "_pre_loaded1"
+            return data
+
+        @staticmethod
+        @mr.pre_load
+        def pre_load2(data: dict[str, Any]) -> dict[str, Any]:
+            data["x"] = data["x"] + "_pre_loaded2"
+            return data
+
+    add_pre_load(MyClass, lambda data: {**data, "x": data["x"] + "_pre_loaded3"})
+
+    assert mr.load(MyClass, {"x": "value"}) == MyClass(x="value_pre_loaded1_pre_loaded2_pre_loaded3")
+
+
+def test_deserialize_with_pre_load_decorator() -> None:
+    def strip_strings(cls: Any) -> Any:
+        def pre_load(data: dict[str, Any]) -> dict[str, Any]:
+            return {k: pre_load_value(v) for k, v in data.items()}
+
+        def pre_load_value(value: Any) -> Any:
+            if not isinstance(value, str):
+                return value
+            return value.strip()
+
+        add_pre_load(cls, pre_load)
+        return cls
+
+    @dataclasses.dataclass
+    @strip_strings
+    class MyClass:
+        x: str | None
+
+    assert mr.load(MyClass, {"x": "  abc  "}) == MyClass(x="abc")


### PR DESCRIPTION
Use case 1 (static method):
```python
import marshmallow_recipe as mr

@dataclass
class SomeClass:
    field: str

    @staticmethod
    @mr.pre_load    
    def pre_load(data: dict[str, Any]) -> dict[str, Any]:
        return {k: v + "_pre_loaded" for k, v in data.items()}

assert mr.load(SomeClass, {"field": "value"}) == {"field": "value_pre_loaded"}
```

Use case 2 (explicitly added hook):
```python
@dataclass
class SomeClass:
    field: str

def pre_load(data: dict[str, Any]) -> dict[str, Any]:
    return {k: v + "_pre_loaded" for k, v in data.items()}

mr.add_pre_load(SomeClass, pre_load)

assert mr.load(SomeClass, {"field": "value"}) == {"field": "value_pre_loaded"}
```

Use case 3 (explicitly added hook used in decorator):
```python
def strip_strings(cls: Any) -> Any:
    def pre_load(data: dict[str, Any]) -> dict[str, Any]:
        return {k: v.strip() if isinstance(v, str) else v for k, v in data.items()}

    mr.add_pre_load(cls, pre_load)

@dataclass
@strip_strings
class SomeClass:
    field: str

assert mr.load(SomeClass, {"field": "  value  "}) == {"field": "value"}
```