### PR TITLE
Metadata name should not use others field name

### DIFF
--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -172,7 +172,7 @@ else:
 
             @m.pre_load  # type: ignore
             def pre_load(self, data: dict[str, Any]) -> Any:
-                # Exclude unknown fields
+                # Exclude unknown fields to prevent possible value overlapping
                 known_fields = {field.load_from or field.name for field in self.fields.values()}  # type: ignore
                 fields = list(data.keys())
                 for key in fields:

--- a/tests/test_unknown_fields.py
+++ b/tests/test_unknown_fields.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+import pytest
+
 import marshmallow_recipe as mr
 
 
@@ -10,3 +12,15 @@ def test_unknown_fields_should_be_excluded() -> None:
 
     expected = mr.load(Example, {"field_1": "bad", "field_2": "good"})
     assert expected == Example(field_1="good")
+
+
+def test_metadata_name_should_not_use_others_field_name() -> None:
+    @dataclasses.dataclass
+    class Example:
+        field_1: str = dataclasses.field(metadata=mr.metadata(name="field_2"))
+        field_2: str
+
+    with pytest.raises(ValueError) as e:
+        mr.load(Example, {"field_1": "bad", "field_2": "good"})
+
+    assert e.value.args[0] == "Invalid name=field_2 in metadata for field=field_1"


### PR DESCRIPTION
In case of overlapping, marshmallow 2 works incorrectly:

```python
@dataclasses.dataclass
class Example:
    field_1: str = dataclasses.field(metadata=mr.metadata(name="field_2"))
    field_2: str = dataclasses.field(metadata=mr.metadata(name="field_1"))

mr.load(Example, {"field_1": "bad", "field_2": "good"})
# Example(field_1="bad", field_2="good")
```