### PR TITLE
export local Schema and ValidationError

### DIFF
--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -3,11 +3,13 @@ import re
 import sys
 
 from .bake import bake_schema, get_field_for
+from .errors import ValidationError
 from .hooks import add_pre_load, pre_load
 from .metadata import datetime_metadata, decimal_metadata, metadata
 from .missing import MISSING
 from .naming_case import CAMEL_CASE, CAPITAL_CAMEL_CASE, DEFAULT_CASE, CamelCase, CapitalCamelCase, NamingCase
 from .options import NoneValueHandling, options
+from .schema import Schema
 from .serialization import EmptySchema, dump, dump_many, load, load_many, schema
 
 __all__: tuple[str, ...] = (
@@ -33,6 +35,8 @@ __all__: tuple[str, ...] = (
     "datetime_metadata",
     "pre_load",
     "add_pre_load",
+    "Schema",
+    "ValidationError",
 )
 
 __version__ = "0.0.17"

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -28,6 +28,7 @@ from .fields import (
 from .hooks import get_pre_loads
 from .naming_case import NamingCase
 from .options import NoneValueHandling, get_options_for
+from .schema import Schema
 
 _T = TypeVar("_T")
 _MARSHMALLOW_VERSION_MAJOR = int(m.__version__.split(".")[0])
@@ -37,7 +38,7 @@ def bake_schema(
     cls: Type[_T],
     *,
     naming_case: NamingCase | None = None,
-) -> Type[m.Schema]:
+) -> Type[Schema]:
     if not dataclasses.is_dataclass(cls):
         raise ValueError(f"{cls} is not a dataclass")
 
@@ -68,7 +69,7 @@ def bake_schema(
             for field, metadata in fields_with_metadata
         },
     )
-    return cast(Type[m.Schema], schema_class)
+    return cast(Type[Schema], schema_class)
 
 
 def get_field_for(
@@ -130,8 +131,8 @@ def get_field_for(
 
 if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
-    def _get_base_schema(cls: Type[_T], none_value_handling: NoneValueHandling) -> Type[m.Schema]:
-        class _Schema(m.Schema):
+    def _get_base_schema(cls: Type[_T], none_value_handling: NoneValueHandling) -> Type[Schema]:
+        class _Schema(Schema):
             class Meta:
                 unknown = m.EXCLUDE
 
@@ -156,8 +157,8 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
 else:
 
-    def _get_base_schema(cls: Type[_T], none_value_handling: NoneValueHandling) -> Type[m.Schema]:
-        class _Schema(m.Schema):  # type: ignore
+    def _get_base_schema(cls: Type[_T], none_value_handling: NoneValueHandling) -> Type[Schema]:
+        class _Schema(Schema):  # type: ignore
             @m.post_dump  # type: ignore
             def remove_none_values(self, data: dict[str, Any]) -> dict[str, Any]:
                 if none_value_handling == NoneValueHandling.IGNORE:

--- a/marshmallow_recipe/errors.py
+++ b/marshmallow_recipe/errors.py
@@ -1,0 +1,5 @@
+import marshmallow as m
+
+
+class ValidationError(m.ValidationError):
+    pass

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -6,6 +6,9 @@ from typing import Any, Callable, Iterable, Type, cast
 import marshmallow as m
 import marshmallow.validate
 
+from .errors import ValidationError
+from .schema import Schema
+
 _MARSHMALLOW_VERSION_MAJOR = int(m.__version__.split(".")[0])
 
 
@@ -270,7 +273,7 @@ def date_field(
 
 
 def nested_field(
-    nested_schema: Type[m.Schema],
+    nested_schema: Type[Schema],
     *,
     required: bool,
     allow_none: bool,
@@ -523,10 +526,10 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
                 return cast(Callable[[str], enum.Enum], self.enum_type)(string_value)
             except ValueError:
                 if self.extendable_default is m.missing:
-                    raise m.ValidationError(self.default_error.format(input=value, choices=self.choices))
+                    raise ValidationError(self.default_error.format(input=value, choices=self.choices))
                 return self.extendable_default
             except Exception:
-                raise m.ValidationError(self.default_error.format(input=value, choices=self.choices))
+                raise ValidationError(self.default_error.format(input=value, choices=self.choices))
 
         @staticmethod
         def _validate_enum(enum_type: Any) -> None:
@@ -656,10 +659,10 @@ else:
                 return cast(Callable[[str], enum.Enum], self.enum_type)(string_value)
             except ValueError:
                 if self.extendable_default is m.missing:
-                    raise m.ValidationError(self.default_error.format(input=value, choices=self.choices))
+                    raise ValidationError(self.default_error.format(input=value, choices=self.choices))
                 return self.extendable_default
             except Exception:
-                raise m.ValidationError(self.default_error.format(input=value, choices=self.choices))
+                raise ValidationError(self.default_error.format(input=value, choices=self.choices))
 
         @staticmethod
         def _validate_enum(enum_type: Any) -> None:

--- a/marshmallow_recipe/schema.py
+++ b/marshmallow_recipe/schema.py
@@ -1,0 +1,5 @@
+import marshmallow as m
+
+
+class Schema(m.Schema):
+    pass

--- a/marshmallow_recipe/serialization.py
+++ b/marshmallow_recipe/serialization.py
@@ -4,7 +4,9 @@ from typing import Any, Type, TypeVar, cast
 import marshmallow as m
 
 from .bake import bake_schema
+from .errors import ValidationError
 from .naming_case import NamingCase
+from .schema import Schema
 
 _T = TypeVar("_T")
 _MARSHMALLOW_VERSION_MAJOR = int(m.__version__.split(".")[0])
@@ -17,11 +19,11 @@ class _SchemaKey:
     naming_case: NamingCase | None
 
 
-_schemas: dict[_SchemaKey, m.Schema] = {}
+_schemas: dict[_SchemaKey, Schema] = {}
 
 if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
-    def schema(cls: Type[_T], *, many: bool = False, naming_case: NamingCase | None = None) -> m.Schema:
+    def schema(cls: Type[_T], *, many: bool = False, naming_case: NamingCase | None = None) -> Schema:
         key = _SchemaKey(cls=cls, many=many, naming_case=naming_case)
         existent_schema = _schemas.get(key)
         if existent_schema is not None:
@@ -46,7 +48,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
         data_schema = schema(type(data), naming_case=naming_case)
         dumped: dict[str, Any] = data_schema.dump(data)
         if errors := data_schema.validate(dumped):
-            raise m.ValidationError(errors)
+            raise ValidationError(errors)
         return dumped
 
     def dump_many(data: list[_T], *, naming_case: NamingCase | None = None) -> list[dict[str, Any]]:
@@ -55,12 +57,12 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
         data_schema = schema(type(data[0]), many=True, naming_case=naming_case)
         dumped: list[dict[str, Any]] = data_schema.dump(data)
         if errors := data_schema.validate(dumped):
-            raise m.ValidationError(errors)
+            raise ValidationError(errors)
         return dumped
 
 else:
 
-    def schema(cls: Type[_T], *, many: bool = False, naming_case: NamingCase | None = None) -> m.Schema:
+    def schema(cls: Type[_T], *, many: bool = False, naming_case: NamingCase | None = None) -> Schema:
         key = _SchemaKey(cls=cls, many=many, naming_case=naming_case)
         existent_schema = _schemas.get(key)
         if existent_schema is not None:
@@ -92,4 +94,4 @@ else:
         return cast(list[dict[str, Any]], dumped)
 
 
-EmptySchema = m.Schema
+EmptySchema = Schema


### PR DESCRIPTION
This improvement enhances end-service abstration level and lets avoid

```
import marshmallow
```
in most common cases