### PR TITLE
Cache get_pre_loads results

### DIFF
--- a/marshmallow_recipe/hooks.py
+++ b/marshmallow_recipe/hooks.py
@@ -4,6 +4,7 @@ from typing import Any
 
 _PRE_LOAD_KEY = "__marshmallow_recipe_pre_load__"
 _PRE_LOAD_CLASS_KEY = "__marshmallow_recipe_pre_load_class__"
+_PRE_LOADS_CACHE = {}
 
 
 def pre_load(fn: collections.abc.Callable[..., Any]) -> collections.abc.Callable[..., Any]:
@@ -12,12 +13,17 @@ def pre_load(fn: collections.abc.Callable[..., Any]) -> collections.abc.Callable
 
 
 def get_pre_loads(cls: type) -> list[collections.abc.Callable[..., Any]]:
+    existing = _PRE_LOADS_CACHE.get(cls)
+    if existing is not None:
+        return existing
+
     result = []
     for _, method in inspect.getmembers(cls):
         if hasattr(method, _PRE_LOAD_KEY):
             result.append(method)
     for fn in getattr(cls, _PRE_LOAD_CLASS_KEY, []):
         result.append(fn)
+    _PRE_LOADS_CACHE[cls] = result
     return result
 
 

--- a/marshmallow_recipe/hooks.py
+++ b/marshmallow_recipe/hooks.py
@@ -1,10 +1,10 @@
 import collections.abc
+import functools
 import inspect
 from typing import Any
 
 _PRE_LOAD_KEY = "__marshmallow_recipe_pre_load__"
 _PRE_LOAD_CLASS_KEY = "__marshmallow_recipe_pre_load_class__"
-_PRE_LOADS_CACHE = {}
 
 
 def pre_load(fn: collections.abc.Callable[..., Any]) -> collections.abc.Callable[..., Any]:
@@ -12,18 +12,14 @@ def pre_load(fn: collections.abc.Callable[..., Any]) -> collections.abc.Callable
     return fn
 
 
+@functools.cache
 def get_pre_loads(cls: type) -> list[collections.abc.Callable[..., Any]]:
-    existing = _PRE_LOADS_CACHE.get(cls)
-    if existing is not None:
-        return existing
-
     result = []
     for _, method in inspect.getmembers(cls):
         if hasattr(method, _PRE_LOAD_KEY):
             result.append(method)
     for fn in getattr(cls, _PRE_LOAD_CLASS_KEY, []):
         result.append(fn)
-    _PRE_LOADS_CACHE[cls] = result
     return result
 
 


### PR DESCRIPTION
PR adds some caching for `get_pre_loads`. As illustrated further by `benchmarks/transaction_load_dump.py` example, time needed is reduced from 0.306 seconds to 0.178 seconds (42% decrease). 

w/o cache:

```
696392 function calls (693320 primitive calls) in 0.306 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2048    0.056    0.000    0.102    0.000 inspect.py:550(_getmembers)
   2050/2    0.019    0.000    0.140    0.070 schema.py:575(_deserialize)
     2048    0.017    0.000    0.126    0.000 hooks.py:15(get_pre_loads)
    10240    0.012    0.000    0.088    0.000 fields.py:342(deserialize)
     2048    0.009    0.000    0.009    0.000 {built-in method builtins.dir}
     2048    0.009    0.000    0.025    0.000 utils.py:145(from_iso_datetime)
```

with cache:

```
313416 function calls (310344 primitive calls) in 0.178 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   2050/2    0.019    0.000    0.139    0.069 schema.py:575(_deserialize)
    10240    0.012    0.000    0.087    0.000 fields.py:342(deserialize)
     2048    0.009    0.000    0.025    0.000 utils.py:145(from_iso_datetime)
     6144    0.007    0.000    0.010    0.000 fields.py:1091(_format_num)
     8192    0.006    0.000    0.016    0.000 fields.py:263(_validate)
```