### PR TITLE
Use native isoformat/fromisoformat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+* [Use native isoformat/fromisoformat](https://github.com/anna-money/marshmallow-recipe/pull/141)
+
+
 ## v0.0.37(2023-12-11)
 
 * [Cache get_pre_loads results](https://github.com/anna-money/marshmallow-recipe/pull/140)

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -634,8 +634,8 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
     StrField = StrFieldV3
 
     class DateTimeFieldV3(m.fields.DateTime):
-        DATEFORMAT_SERIALIZATION_FUNCS = {
-            **m.fields.DateTime.DATEFORMAT_SERIALIZATION_FUNCS,
+        SERIALIZATION_FUNCS = {
+            **m.fields.DateTime.SERIALIZATION_FUNCS,  # type: ignore
             **(
                 {
                     "iso": datetime.datetime.isoformat,
@@ -645,8 +645,8 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
                 else {}
             ),
         }
-        DATEFORMAT_DESERIALIZATION_FUNCS = {
-            **m.fields.DateTime.DATEFORMAT_DESERIALIZATION_FUNCS,
+        DESERIALIZATION_FUNCS = {
+            **m.fields.DateTime.DESERIALIZATION_FUNCS,  # type: ignore
             **(
                 {
                     "iso": datetime.datetime.fromisoformat,
@@ -865,7 +865,7 @@ else:
             return datetime.datetime.isoformat(v)
 
         DATEFORMAT_SERIALIZATION_FUNCS = {
-            **m.fields.DateTime.DATEFORMAT_SERIALIZATION_FUNCS,
+            **m.fields.DateTime.DATEFORMAT_SERIALIZATION_FUNCS,  # type: ignore
             **(
                 {
                     "iso": __isoformat,
@@ -876,7 +876,7 @@ else:
             ),
         }
         DATEFORMAT_DESERIALIZATION_FUNCS = {
-            **m.fields.DateTime.DATEFORMAT_DESERIALIZATION_FUNCS,
+            **m.fields.DateTime.DATEFORMAT_DESERIALIZATION_FUNCS,  # type: ignore
             **(
                 {
                     "iso": datetime.datetime.fromisoformat,

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -645,6 +645,16 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
                 else {}
             ),
         }
+
+        @staticmethod
+        def __fromisoformat_py310_fix(
+            format: str, value: str
+        ) -> datetime.datetime:  # pyright: ignore[reportUnusedFunction]
+            try:
+                return m.fields.DateTime.DESERIALIZATION_FUNCS[format](value)  # type: ignore
+            except ValueError:
+                return datetime.datetime.strptime(value, "%Y-%m-%d")
+
         DESERIALIZATION_FUNCS = {
             **m.fields.DateTime.DESERIALIZATION_FUNCS,  # type: ignore
             **(
@@ -653,7 +663,10 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
                     "iso8601": datetime.datetime.fromisoformat,
                 }
                 if sys.version_info >= (3, 11)
-                else {}
+                else {
+                    "iso": lambda x: DateTimeFieldV3.__fromisoformat_py310_fix("iso", x),
+                    "iso8601": lambda x: DateTimeFieldV3.__fromisoformat_py310_fix("iso8601", x),
+                }
             ),
         }
 
@@ -877,6 +890,16 @@ else:
                 else {}
             ),
         }
+
+        @staticmethod
+        def __fromisoformat_py310_fix(
+            format: str, value: str
+        ) -> datetime.datetime:  # pyright: ignore[reportUnusedFunction]
+            try:
+                return m.fields.DateTime.DATEFORMAT_DESERIALIZATION_FUNCS[format](value)  # type: ignore
+            except ValueError:
+                return datetime.datetime.strptime(value, "%Y-%m-%d")
+
         DATEFORMAT_DESERIALIZATION_FUNCS = {
             **m.fields.DateTime.DATEFORMAT_DESERIALIZATION_FUNCS,  # type: ignore
             **(
@@ -885,7 +908,10 @@ else:
                     "iso8601": datetime.datetime.fromisoformat,
                 }
                 if sys.version_info >= (3, 11)
-                else {}
+                else {
+                    "iso": lambda x: DateTimeFieldV2.__fromisoformat_py310_fix("iso", x),
+                    "iso8601": lambda x: DateTimeFieldV2.__fromisoformat_py310_fix("iso8601", x),
+                }
             ),
         }
 

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -661,6 +661,8 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
             result = super()._deserialize(value, attr, data, **kwargs)
             if result.tzinfo is None:
                 return result.replace(tzinfo=datetime.timezone.utc)
+            if result.tzinfo == datetime.timezone.utc:
+                return result
             return result.astimezone(datetime.timezone.utc)
 
         def _serialize(self, value: Any, attr: Any, obj: Any, **kwargs: Any) -> Any:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -374,6 +374,7 @@ def test_many_empty() -> None:
         ("2022-02-20T11:33:48", datetime.datetime(2022, 2, 20, 11, 33, 48, 0, datetime.timezone.utc)),
         ("2022-02-20T11:33:48.607289Z", datetime.datetime(2022, 2, 20, 11, 33, 48, 607289, datetime.timezone.utc)),
         ("2022-02-20T11:33:48Z", datetime.datetime(2022, 2, 20, 11, 33, 48, 0, datetime.timezone.utc)),
+        ("2022-02-20", datetime.datetime(2022, 2, 20, 0, 0, 0, 0, datetime.timezone.utc)),
     ],
 )
 def test_datetime_field_load(raw: str, dt: datetime.datetime) -> None:
@@ -392,6 +393,7 @@ def test_datetime_field_load(raw: str, dt: datetime.datetime) -> None:
         (datetime.datetime(2022, 2, 20, 11, 33, 48, 0, datetime.timezone.utc), "2022-02-20T11:33:48+00:00"),
         (datetime.datetime(2022, 2, 20, 11, 33, 48, 607289, None), "2022-02-20T11:33:48.607289+00:00"),
         (datetime.datetime(2022, 2, 20, 11, 33, 48, 0, None), "2022-02-20T11:33:48+00:00"),
+        (datetime.datetime(2022, 2, 20, 0, 0, 0, 0, None), "2022-02-20T00:00:00+00:00"),
     ],
 )
 def test_datetime_field_dump(dt: datetime.datetime, raw: str) -> None:


### PR DESCRIPTION
The PR replaces iso parsing/formatting function with built in one, which were fixed starting from python 3.11.

27% time decrease for marshmallow 2.21, 17% time decrease for mashmallow 3.21.