### PR TITLE
Almost stop using marshmallow defaults (except Nones)

### DIFF
--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -53,7 +53,7 @@ def str_field(
         validate=validate,
         strip_whitespaces=strip_whitespaces,
         post_load=post_load,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -84,7 +84,7 @@ def bool_field(
     return m.fields.Bool(
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -127,7 +127,7 @@ def decimal_field(
         as_string=as_string,
         places=places,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -157,7 +157,7 @@ def int_field(
     return m.fields.Int(
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -187,7 +187,7 @@ def float_field(
     return m.fields.Float(
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -217,7 +217,7 @@ def uuid_field(
     return m.fields.UUID(
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -252,7 +252,7 @@ def datetime_field(
         allow_none=allow_none,
         validate=validate,
         format=format,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -282,7 +282,7 @@ def time_field(
     return m.fields.Time(
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -312,7 +312,7 @@ def date_field(
     return m.fields.Date(
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -347,7 +347,7 @@ def nested_field(
         nested_schema,
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -380,7 +380,7 @@ def list_field(
         field,
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -413,7 +413,7 @@ def set_field(
         field,
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -446,7 +446,7 @@ def frozen_set_field(
         field,
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -479,7 +479,7 @@ def tuple_field(
         field,
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -522,7 +522,7 @@ def dict_field(
         values=values_field,
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -561,7 +561,7 @@ def enum_field(
         enum_type=enum_type,
         allow_none=allow_none,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 
@@ -576,7 +576,7 @@ def raw_field(
     return m.fields.Raw(
         allow_none=True,
         validate=validate,
-        **default_fields(None if default is dataclasses.MISSING else default),
+        **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
     )
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -568,3 +568,15 @@ def test_str_post_load() -> None:
 
     assert StrContainer(value1="111111", value2=None) == mr.load(StrContainer, {"value1": "11-11-11"})
     assert mr.dump(StrContainer(value1="11-11-11", value2=None)) == {"value1": "11-11-11"}
+
+
+def test_nested_default() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class IntContainer:
+        value: int = 42
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class RootContainer:
+        int_container: IntContainer = dataclasses.field(default_factory=IntContainer)
+
+    assert mr.load(RootContainer, {}) == RootContainer()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -156,7 +156,7 @@ def test_simple_types() -> None:
         optional_enum_field="even",
     )
 
-    raw_no_defaults = {k: v for k, v in raw.items() if not k.endswith("default") or not k.endswith("default_factory")}
+    raw_no_defaults = {k: v for k, v in raw.items() if not k.endswith("default") and not k.endswith("default_factory")}
 
     loaded = mr.load(SimpleTypesContainers, raw)
     loaded_no_defaults = mr.load(SimpleTypesContainers, raw_no_defaults)


### PR DESCRIPTION
Due to fix of a typo in tests, it has been found that complex default values don't work for marshmallow2 (it tries to parse a default value via field), but do work for marshmallow3: `test_nested_default` demonstrates the issue for a dataclass field default.

So, as a solution of the issue, I propose to stop settings default values to marshmallow (except Nones for Optional fields, because our schema removes Nones by default).

Known side effects:
1. a default value for such a field will not be shown in Swagger, however it will be not required there.