### PR TITLE
Support generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Supported types:
 - `Mapping` (with typed keys and values), `Set`, `Sequence`
 
 Example:
-class Annotated:
-pass
 
 ```python
 import dataclasses
@@ -76,4 +74,39 @@ assert loaded.annual_turnover is mr.MISSING
 loaded = mr.load(CompanyUpdateData, {"annual_turnover": None})
 assert loaded.name is mr.MISSING
 assert loaded.annual_turnover is None
+```
+
+Also generics are supported. All works automatically except one case. Dump operation of generic dataclass with `frozen=True` or `slots=True` requires explicitly specified subscripted generic type as `cls` argument of `dump` and `dump_many` methods.
+
+```python
+import dataclasses
+from typing import Generic, TypeVar
+import marshmallow_recipe as mr
+
+T = TypeVar("T")
+
+@dataclasses.dataclass()
+class Regular(Generic[T]):
+    value: T
+
+mr.dump(Regular[int](value=123))  # it works without explicit cls arg
+
+@dataclasses.dataclass(frozen=True)
+class Frozen(Generic[T]):
+    value: T
+
+mr.dump(Frozen[int](value=123), cls=Frozen[int])  # cls required for frozen generic
+
+@dataclasses.dataclass(slots=True)
+class Slots(Generic[T]):
+    value: T
+
+mr.dump(Slots[int](value=123), cls=Slots[int])  # cls required for generic with slots
+
+@dataclasses.dataclass(slots=True)
+class SlotsNonGeneric(Slots[int]):
+    pass
+
+mr.dump(SlotsNonGeneric(value=123))  # cls not required
+
 ```

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -52,7 +52,7 @@ _schema_types: dict[_SchemaTypeKey, type[m.Schema]] = {}
 
 class _FieldDescription(NamedTuple):
     field: dataclasses.Field
-    subscripted_type: TypeLike
+    value_type: TypeLike
     metadata: Metadata
 
 
@@ -111,12 +111,12 @@ def bake_schema(
         {"__module__": f"{__package__}.auto_generated"}
         | {
             field.name: get_field_for(
-                data_type,
+                value_type,
                 metadata,
                 naming_case=naming_case,
                 none_value_handling=none_value_handling,
             )
-            for field, data_type, metadata in fields
+            for field, value_type, metadata in fields
         },
     )
     _schema_types[key] = schema_type

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -57,12 +57,12 @@ class _FieldDescription(NamedTuple):
 
 
 def bake_schema(
-    t: type,
+    cls: type,
     *,
     naming_case: NamingCase | None = None,
     none_value_handling: NoneValueHandling | None = None,
 ) -> type[m.Schema]:
-    origin: type = get_origin(t) or t
+    origin: type = get_origin(cls) or cls
     if not dataclasses.is_dataclass(origin):
         raise ValueError(f"{origin} is not a dataclass")
 
@@ -74,14 +74,14 @@ def bake_schema(
         cls_naming_case = naming_case
 
     key = _SchemaTypeKey(
-        cls=t,
+        cls=cls,
         naming_case=cls_naming_case,
         none_value_handling=cls_none_value_handling,
     )
     if result := _schema_types.get(key):
         return result
 
-    fields_type_map = get_fields_type_map(t)
+    fields_type_map = get_fields_type_map(cls)
 
     fields = [
         _FieldDescription(
@@ -106,8 +106,8 @@ def bake_schema(
                 raise ValueError(f"Invalid name={second_name} in metadata for field={second.field.name}")
 
     schema_type = type(
-        t.__name__,
-        (_get_base_schema(t, cls_none_value_handling or NoneValueHandling.IGNORE),),
+        cls.__name__,
+        (_get_base_schema(cls, cls_none_value_handling or NoneValueHandling.IGNORE),),
         {"__module__": f"{__package__}.auto_generated"}
         | {
             field.name: get_field_for(

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -7,7 +7,7 @@ import importlib.metadata
 import inspect
 import types
 import uuid
-from typing import Annotated, Any, Protocol, TypeVar, Union, get_args, get_origin
+from typing import Annotated, Any, NamedTuple, Protocol, TypeVar, Union, cast, get_args, get_origin
 
 import marshmallow as m
 
@@ -30,6 +30,7 @@ from .fields import (
     tuple_field,
     uuid_field,
 )
+from .generics import TypeLike, get_fields_type_map
 from .hooks import get_pre_loads
 from .metadata import EMPTY_METADATA, Metadata, is_metadata
 from .naming_case import NamingCase
@@ -49,16 +50,23 @@ _MARSHMALLOW_VERSION_MAJOR = int(importlib.metadata.version("marshmallow").split
 _schema_types: dict[_SchemaTypeKey, type[m.Schema]] = {}
 
 
+class _FieldDescription(NamedTuple):
+    field: dataclasses.Field
+    subscripted_type: TypeLike
+    metadata: Metadata
+
+
 def bake_schema(
-    cls: type,
+    t: type,
     *,
     naming_case: NamingCase | None = None,
     none_value_handling: NoneValueHandling | None = None,
 ) -> type[m.Schema]:
-    if not dataclasses.is_dataclass(cls):
-        raise ValueError(f"{cls} is not a dataclass")
+    origin: type = get_origin(t) or t
+    if not dataclasses.is_dataclass(origin):
+        raise ValueError(f"{origin} is not a dataclass")
 
-    if options := try_get_options_for(cls):
+    if options := try_get_options_for(origin):
         cls_none_value_handling = none_value_handling or options.none_value_handling
         cls_naming_case = naming_case or options.naming_case
     else:
@@ -66,47 +74,49 @@ def bake_schema(
         cls_naming_case = naming_case
 
     key = _SchemaTypeKey(
-        cls=cls,
+        cls=t,
         naming_case=cls_naming_case,
         none_value_handling=cls_none_value_handling,
     )
     if result := _schema_types.get(key):
         return result
 
-    fields_with_metadata = [
-        (
+    fields_type_map = get_fields_type_map(t)
+
+    fields = [
+        _FieldDescription(
             field,
+            fields_type_map[field.name],
             _get_metadata(
                 name=field.name if cls_naming_case is None else cls_naming_case(field.name),
                 default=_get_field_default(field),
                 metadata=field.metadata,
             ),
         )
-        for field in dataclasses.fields(cls)
+        for field in dataclasses.fields(origin)
         if field.init
     ]
 
-    for field, _ in fields_with_metadata:
-        for other_field, metadata in fields_with_metadata:
-            if field is other_field:
+    for first in fields:
+        for second in fields:
+            if first is second:
                 continue
+            second_name = second.metadata["name"]
+            if first.field.name == second_name:
+                raise ValueError(f"Invalid name={second_name} in metadata for field={second.field.name}")
 
-            other_field_name = metadata["name"]
-            if field.name == other_field_name:
-                raise ValueError(f"Invalid name={other_field_name} in metadata for field={other_field.name}")
-
-    schema_type: type[m.Schema] = type(
-        cls.__name__,
-        (_get_base_schema(cls, cls_none_value_handling or NoneValueHandling.IGNORE),),
+    schema_type = type(
+        t.__name__,
+        (_get_base_schema(t, cls_none_value_handling or NoneValueHandling.IGNORE),),
         {"__module__": f"{__package__}.auto_generated"}
         | {
             field.name: get_field_for(
-                field.type,  # type: ignore
+                data_type,
                 metadata,
                 naming_case=naming_case,
                 none_value_handling=none_value_handling,
             )
-            for field, metadata in fields_with_metadata
+            for field, data_type, metadata in fields
         },
     )
     _schema_types[key] = schema_type
@@ -114,20 +124,18 @@ def bake_schema(
 
 
 def get_field_for(
-    type: type,
+    t: TypeLike,
     metadata: Metadata,
     naming_case: NamingCase | None,
     none_value_handling: NoneValueHandling | None,
 ) -> m.fields.Field:
-    if type is Any:
+    if t is Any:
         return raw_field(**metadata)
 
-    type = _substitute_any_to_open_generic(type)
-
-    if underlying_type_from_optional := _try_get_underlying_type_from_optional(type):
+    if underlying_type_from_optional := _try_get_underlying_type_from_optional(t):
         required = False
         allow_none = True
-        type = underlying_type_from_optional
+        t = underlying_type_from_optional
     elif metadata.get("default", dataclasses.MISSING) is not dataclasses.MISSING:
         required = False
         allow_none = False
@@ -135,19 +143,19 @@ def get_field_for(
         required = True
         allow_none = False
 
-    if inspect.isclass(type) and issubclass(type, enum.Enum):
-        return enum_field(enum_type=type, required=required, allow_none=allow_none, **metadata)
+    if inspect.isclass(t) and issubclass(t, enum.Enum):
+        return enum_field(enum_type=t, required=required, allow_none=allow_none, **metadata)
 
-    if dataclasses.is_dataclass(type):
+    if dataclasses.is_dataclass(get_origin(t) or t):
         return nested_field(
-            bake_schema(type, naming_case=naming_case, none_value_handling=none_value_handling),
+            bake_schema(cast(type, t), naming_case=naming_case, none_value_handling=none_value_handling),
             required=required,
             allow_none=allow_none,
             **metadata,
         )
 
-    if (origin := get_origin(type)) is not None:
-        arguments = get_args(type)
+    if (origin := get_origin(t)) is not None:
+        arguments = get_args(t)
 
         if origin is list or origin is collections.abc.Sequence:
             collection_field_metadata = dict(metadata)
@@ -269,11 +277,11 @@ def get_field_for(
                 none_value_handling=none_value_handling,
             )
 
-    field_factory = _SIMPLE_TYPE_FIELD_FACTORIES.get(type)
-    if field_factory:
+    if t in _SIMPLE_TYPE_FIELD_FACTORIES:
+        field_factory = _SIMPLE_TYPE_FIELD_FACTORIES[t]
         return field_factory(required=required, allow_none=allow_none, **metadata)
 
-    raise ValueError(f"Unsupported {type=}")
+    raise ValueError(f"Unsupported {t=}")
 
 
 if _MARSHMALLOW_VERSION_MAJOR >= 3:
@@ -374,26 +382,12 @@ def _get_metadata(*, name: str, default: Any, metadata: collections.abc.Mapping[
     return Metadata(values)
 
 
-def _substitute_any_to_open_generic(type: type) -> type:
-    if type is list:
-        return list[Any]
-    if type is set:
-        return set[Any]
-    if type is frozenset:
-        return frozenset[Any]
-    if type is dict:
-        return dict[Any, Any]
-    if type is tuple:
-        return tuple[Any, ...]
-    return type
-
-
-def _try_get_underlying_type_from_optional(type: type) -> type | None:
+def _try_get_underlying_type_from_optional(t: TypeLike) -> TypeLike | None:
     # to support Union[int, None] and int | None
-    if get_origin(type) is Union or isinstance(type, types.UnionType):  # type: ignore
-        type_args = get_args(type)
+    if get_origin(t) is Union or isinstance(t, types.UnionType):  # type: ignore
+        type_args = get_args(t)
         if types.NoneType not in type_args or len(type_args) != 2:
-            raise ValueError(f"Unsupported {type=}")
+            raise ValueError(f"Unsupported {t=}")
         return next(type_arg for type_arg in type_args if type_arg is not types.NoneType)  # noqa
 
     return None

--- a/marshmallow_recipe/generics.py
+++ b/marshmallow_recipe/generics.py
@@ -1,14 +1,10 @@
 import dataclasses
 import types
 import typing
-from typing import TYPE_CHECKING, Annotated, Any, Generic, TypeAlias, TypeVar, Union, get_args, get_origin
+from typing import Annotated, Any, Generic, TypeAlias, TypeVar, Union, get_args, get_origin
 
 _GenericAlias: TypeAlias = typing._GenericAlias  # type: ignore
 
-if TYPE_CHECKING:
-    from _typeshed import DataclassInstance
-else:
-    DataclassInstance: TypeAlias = type
 
 TypeLike: TypeAlias = type | TypeVar | types.UnionType | types.GenericAlias | _GenericAlias
 FieldsTypeMap: TypeAlias = dict[str, TypeLike]
@@ -48,7 +44,10 @@ def get_fields_type_map(cls: type) -> FieldsTypeMap:
     }
 
 
-def get_fields_class_map(cls: type[DataclassInstance]) -> FieldsClassMap:
+def get_fields_class_map(cls: type) -> FieldsClassMap:
+    if not dataclasses.is_dataclass(cls):
+        raise ValueError(f"{cls} is not a dataclass")
+
     names: dict[str, dataclasses.Field] = {}
     result: FieldsClassMap = {}
 

--- a/marshmallow_recipe/generics.py
+++ b/marshmallow_recipe/generics.py
@@ -1,0 +1,117 @@
+import dataclasses
+import typing
+from dataclasses import Field
+from types import GenericAlias, UnionType
+from typing import Annotated, Any, Generic, TypeAlias, TypeVar, Union, get_args, get_origin
+
+_GenericAlias: TypeAlias = typing._GenericAlias  # type: ignore
+
+TypeLike: TypeAlias = type | TypeVar | UnionType | GenericAlias | _GenericAlias
+TypeVarMap: TypeAlias = dict[TypeVar, TypeLike]
+ClassTypeVarMap: TypeAlias = dict[TypeLike, TypeVarMap]
+FieldsTypeVarMap: TypeAlias = dict[str, TypeVarMap]
+FieldsClassMap: TypeAlias = dict[str, TypeLike]
+FieldsTypeMap: TypeAlias = dict[str, TypeLike]
+
+
+def get_fields_type_map(t: TypeLike) -> FieldsTypeMap:
+    origin = get_origin(t) or t
+    if not dataclasses.is_dataclass(origin):
+        return {}
+
+    class_type_var_map = get_class_type_var_map(t)
+    fields_type_map = get_fields_class_map(t)
+    return {
+        f.name: build_subscripted_type(f.type, class_type_var_map.get(fields_type_map[f.name], {}))
+        for f in dataclasses.fields(origin)
+    }
+
+
+def get_fields_class_map(t: TypeLike) -> FieldsClassMap:
+    origin = get_origin(t) or t
+    if not dataclasses.is_dataclass(origin):
+        return {}
+
+    names: dict[str, Field] = {}
+    result: FieldsClassMap = {}
+
+    mro = origin.__mro__  # type: ignore
+    for base in (*mro[-1:0:-1], origin):
+        if not dataclasses.is_dataclass(base):
+            continue
+        for field in dataclasses.fields(base):
+            if names.get(field.name) != field:
+                names[field.name] = field
+                result[field.name] = base
+    return result
+
+
+def build_subscripted_type(t: TypeLike, type_var_map: TypeVarMap) -> TypeLike:
+    if isinstance(t, TypeVar):
+        return build_subscripted_type(type_var_map[t], type_var_map)
+
+    origin = get_origin(t)
+    if origin is Union or isinstance(t, UnionType):
+        return Union[*(build_subscripted_type(x, type_var_map) for x in get_args(t))]  # type: ignore
+
+    if origin is Annotated:
+        t, *annotations = get_args(t)
+        return Annotated[build_subscripted_type(t, type_var_map), *annotations]  # type: ignore
+
+    if origin and isinstance(t, GenericAlias):
+        return GenericAlias(origin, tuple(build_subscripted_type(x, type_var_map) for x in get_args(t)))
+
+    if origin and isinstance(t, _GenericAlias):
+        return _GenericAlias(origin, tuple(build_subscripted_type(x, type_var_map) for x in get_args(t)))
+
+    return _subscript_with_any(t)
+
+
+def get_class_type_var_map(t: TypeLike) -> ClassTypeVarMap:
+    class_type_var_map: ClassTypeVarMap = {}
+    _get_class_type_var_map(t, class_type_var_map)
+    return class_type_var_map
+
+
+def _get_class_type_var_map(t: TypeLike, class_type_var_map: ClassTypeVarMap) -> None:
+    if _get_parameters(t):
+        raise Exception(f"Expected subscripted generic, but got unsubscripted {t}")
+
+    type_var_map: TypeVarMap = {}
+    origin = get_origin(t) or t
+    parameters = _get_parameters(origin)
+    args = get_args(t)
+    if parameters or args:
+        if not parameters or not args or len(parameters) != len(args):
+            raise Exception(f"Unexpected generic {t}")
+        class_type_var_map[origin] = type_var_map
+        for i, parameter in enumerate(parameters):
+            assert isinstance(parameter, TypeVar)
+            type_var_map[parameter] = args[i]
+
+    if orig_bases := _get_orig_bases(origin):
+        for orig_base in orig_bases:
+            if get_origin(orig_base) is not Generic:
+                _get_class_type_var_map(build_subscripted_type(orig_base, type_var_map), class_type_var_map)
+
+
+def _get_parameters(t: Any) -> tuple[TypeLike, ...] | None:
+    return hasattr(t, "__parameters__") and getattr(t, "__parameters__") or None
+
+
+def _get_orig_bases(t: Any) -> tuple[TypeLike, ...] | None:
+    return hasattr(t, "__orig_bases__") and getattr(t, "__orig_bases__") or None
+
+
+def _subscript_with_any(t: TypeLike) -> TypeLike:
+    if t is list:
+        return list[Any]
+    if t is set:
+        return set[Any]
+    if t is frozenset:
+        return frozenset[Any]
+    if t is dict:
+        return dict[Any, Any]
+    if t is tuple:
+        return tuple[Any, ...]
+    return t

--- a/marshmallow_recipe/generics.py
+++ b/marshmallow_recipe/generics.py
@@ -6,11 +6,11 @@ from typing import Annotated, Any, Generic, TypeAlias, TypeVar, Union, get_args,
 _GenericAlias: TypeAlias = typing._GenericAlias  # type: ignore
 
 TypeLike: TypeAlias = type | TypeVar | types.UnionType | types.GenericAlias | _GenericAlias
+FieldsTypeMap: TypeAlias = dict[str, TypeLike]
 TypeVarMap: TypeAlias = dict[TypeVar, TypeLike]
+FieldsClassMap: TypeAlias = dict[str, TypeLike]
 ClassTypeVarMap: TypeAlias = dict[TypeLike, TypeVarMap]
 FieldsTypeVarMap: TypeAlias = dict[str, TypeVarMap]
-FieldsClassMap: TypeAlias = dict[str, TypeLike]
-FieldsTypeMap: TypeAlias = dict[str, TypeLike]
 
 
 def get_fields_type_map(t: TypeLike) -> FieldsTypeMap:
@@ -52,11 +52,11 @@ def build_subscripted_type(t: TypeLike, type_var_map: TypeVarMap) -> TypeLike:
 
     origin = get_origin(t)
     if origin is Union or origin is types.UnionType:
-        return Union[*(build_subscripted_type(x, type_var_map) for x in get_args(t))]  # type: ignore
+        return Union[*(build_subscripted_type(x, type_var_map) for x in get_args(t))]
 
     if origin is Annotated:
         t, *annotations = get_args(t)
-        return Annotated[build_subscripted_type(t, type_var_map), *annotations]  # type: ignore
+        return Annotated[build_subscripted_type(t, type_var_map), *annotations]
 
     if origin and isinstance(t, types.GenericAlias):
         return types.GenericAlias(origin, tuple(build_subscripted_type(x, type_var_map) for x in get_args(t)))

--- a/marshmallow_recipe/generics.py
+++ b/marshmallow_recipe/generics.py
@@ -102,10 +102,15 @@ def _build_class_type_var_map(t: TypeLike, class_type_var_map: ClassTypeVarMap) 
     if params or args:
         if not params or not args or len(params) != len(args):
             raise ValueError(f"Unexpected generic {t}")
-        class_type_var_map[origin] = type_var_map
         for i, parameter in enumerate(params):
             assert isinstance(parameter, TypeVar)
             type_var_map[parameter] = args[i]
+        if origin not in class_type_var_map:
+            class_type_var_map[origin] = type_var_map
+        elif class_type_var_map[origin] != type_var_map:
+            raise ValueError(
+                f"Incompatible Base class {origin} with generic args {class_type_var_map[origin]} and {type_var_map}"
+            )
 
     if orig_bases := _get_orig_bases(origin):
         for orig_base in orig_bases:

--- a/marshmallow_recipe/generics.py
+++ b/marshmallow_recipe/generics.py
@@ -125,15 +125,15 @@ def _is_unsubscripted_type(t: TypeLike) -> bool:
 
 
 def _get_orig_class(t: Any) -> type | None:
-    return hasattr(t, "__orig_class__") and getattr(t, "__orig_class__") or None
+    return getattr(t, "__orig_class__", None)
 
 
 def _get_params(t: Any) -> tuple[TypeLike, ...] | None:
-    return hasattr(t, "__parameters__") and getattr(t, "__parameters__") or None
+    return getattr(t, "__parameters__", None)
 
 
 def _get_orig_bases(t: Any) -> tuple[TypeLike, ...] | None:
-    return hasattr(t, "__orig_bases__") and getattr(t, "__orig_bases__") or None
+    return getattr(t, "__orig_bases__", None)
 
 
 def _subscript_with_any(t: TypeLike) -> TypeLike:

--- a/marshmallow_recipe/serialization.py
+++ b/marshmallow_recipe/serialization.py
@@ -50,8 +50,9 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
         /,
         *,
         naming_case: NamingCase | None = None,
+        t: type | None = None,
     ) -> dict[str, Any]:
-        data_schema = schema_v3(type(data), naming_case=naming_case)
+        data_schema = schema_v3(t or type(data), naming_case=naming_case)
         dumped: dict[str, Any] = data_schema.dump(data)  # type: ignore
         if errors := data_schema.validate(dumped):
             raise m.ValidationError(errors)
@@ -102,8 +103,9 @@ else:
         /,
         *,
         naming_case: NamingCase | None = None,
+        t: type | None = None,
     ) -> dict[str, Any]:
-        data_schema = schema_v2(type(data), naming_case=naming_case)
+        data_schema = schema_v2(t or type(data), naming_case=naming_case)
         dumped, errors = data_schema.dump(data)
         if errors:
             raise m.ValidationError(errors)

--- a/marshmallow_recipe/serialization.py
+++ b/marshmallow_recipe/serialization.py
@@ -46,8 +46,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     load_many = load_many_v3
 
-    def dump_v3(cls: type | None, data: Any, /,
-        *, naming_case: NamingCase | None = None) -> dict[str, Any]:
+    def dump_v3(cls: type | None, data: Any, /, *, naming_case: NamingCase | None = None) -> dict[str, Any]:
         data_schema = schema_v3(extract_type(data, cls), naming_case=naming_case)
         dumped: dict[str, Any] = data_schema.dump(data)  # type: ignore
         if errors := data_schema.validate(dumped):
@@ -96,8 +95,7 @@ else:
 
     load_many = load_many_v2
 
-    def dump_v2(cls: type | None, data: Any, /,
-        *, naming_case: NamingCase | None = None) -> dict[str, Any]:
+    def dump_v2(cls: type | None, data: Any, /, *, naming_case: NamingCase | None = None) -> dict[str, Any]:
         data_schema = schema_v2(extract_type(data, cls), naming_case=naming_case)
         dumped, errors = data_schema.dump(data)
         if errors:
@@ -127,20 +125,11 @@ EmptySchema = m.Schema
 
 
 @overload
-def dump(
-    data: Any,
-    *,
-    naming_case: NamingCase | None = None,
-) -> dict[str, Any]: ...
+def dump(data: Any, /, *, naming_case: NamingCase | None = None) -> dict[str, Any]: ...
 
 
 @overload
-def dump(
-    cls: type,
-    data: Any,
-    *,
-    naming_case: NamingCase | None = None,
-) -> dict[str, Any]: ...
+def dump(cls: type, data: Any, /, *, naming_case: NamingCase | None = None) -> dict[str, Any]: ...
 
 
 def dump(*args: Any, **kwargs: Any) -> dict[str, Any]:
@@ -150,20 +139,11 @@ def dump(*args: Any, **kwargs: Any) -> dict[str, Any]:
 
 
 @overload
-def dump_many(
-    data: list[Any],
-    *,
-    naming_case: NamingCase | None = None,
-) -> list[dict[str, Any]]: ...
+def dump_many(data: list[Any], /, *, naming_case: NamingCase | None = None) -> list[dict[str, Any]]: ...
 
 
 @overload
-def dump_many(
-    cls: type,
-    data: list[Any],
-    *,
-    naming_case: NamingCase | None = None,
-) -> list[dict[str, Any]]: ...
+def dump_many(cls: type, data: list[Any], /, *, naming_case: NamingCase | None = None) -> list[dict[str, Any]]: ...
 
 
 def dump_many(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:

--- a/marshmallow_recipe/serialization.py
+++ b/marshmallow_recipe/serialization.py
@@ -1,6 +1,6 @@
 import dataclasses
 import importlib.metadata
-from typing import Any, TypeVar
+from typing import Any, TypeVar, get_origin
 
 import marshmallow as m
 
@@ -126,8 +126,12 @@ EmptySchema = m.Schema
 
 
 def _extract_type(data: Any, cls: type | None) -> type:
-    if cls:
-        return cls
     if hasattr(data, "__orig_class__"):
         return getattr(data, "__orig_class__")
-    return type(data)
+    data_type = type(data)
+    if not cls or cls == data_type:
+        return data_type
+    origin = get_origin(cls)
+    if origin != data_type:
+        raise ValueError(f"{cls=} is not subscripted version of {data_type}")
+    return cls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ pytest==8.3.4
 isort==5.13.2
 flake8==7.1.1
 black==24.10.0
-pyright==1.1.391
+pyright==1.1.398
 marshmallow>=2,<4
 
 setuptools

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -80,9 +80,10 @@ def test_get_fields_type_map_generic_inheritance() -> None:
     }
 
 
-def test_get_fields_type_map_non_data_class() -> None:
-    actual = get_fields_type_map(int | None)
-    assert actual == {}
+def test_get_fields_type_map_non_dataclass() -> None:
+    with pytest.raises(ValueError) as e:
+        get_fields_type_map(list[int])
+    assert e.value.args[0] == "<class 'list'> is not a dataclass"
 
 
 def test_get_fields_type_map_not_subscripted() -> None:

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,5 +1,5 @@
 import dataclasses
-from types import UnionType
+import types
 from typing import Annotated, Any, Generic, Iterable, List, TypeVar, Union
 
 import pytest
@@ -236,7 +236,7 @@ _TStr = TypeVar("_TStr")
 _TList = TypeVar("_TList")
 _TDictIntTStr = TypeVar("_TDictIntTStr")
 
-GENERIC_MAP: dict[TypeVar, type[Any] | UnionType] = {
+GENERIC_MAP: dict[TypeVar, type[Any] | types.UnionType] = {
     _TInt: int,
     _TIntNone: int | None,
     _TStr: str,

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,272 @@
+import dataclasses
+from types import UnionType
+from typing import Annotated, Any, Generic, Iterable, List, TypeVar, Union
+
+import pytest
+
+from marshmallow_recipe.generics import (
+    build_subscripted_type,
+    get_class_type_var_map,
+    get_fields_class_map,
+    get_fields_type_map,
+)
+
+
+def test_get_fields_type_map_overrides() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class Value1:
+        v1: str
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class Value2(Value1):
+        v2: str
+
+    _TValue = TypeVar("_TValue", bound=Value1)
+    _TItem = TypeVar("_TItem")
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class T1(Generic[_TItem]):
+        value: Value1
+        iterable: Iterable[_TItem]
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class T2(Generic[_TValue, _TItem], T1[_TItem]):
+        value: _TValue
+        iterable: set[_TItem]
+
+    actual = get_fields_type_map(T2[Value2, int])
+    assert actual == {
+        "value": Value2,
+        "iterable": set[int],
+    }
+
+
+def test_get_fields_type_map_non_generic() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class Value1:
+        v1: int
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class Value2(Value1):
+        v2: bool
+
+    actual = get_fields_type_map(Value2)
+    assert actual == {
+        "v1": int,
+        "v2": bool,
+    }
+
+
+def test_get_fields_type_map_generic_inheritance() -> None:
+    _T = TypeVar("_T")
+
+    @dataclasses.dataclass()
+    class NonGeneric:
+        v: bool
+
+    @dataclasses.dataclass()
+    class Value1(Generic[_T]):
+        v1: _T
+
+    @dataclasses.dataclass()
+    class Value2(Value1[int], NonGeneric):
+        v2: float
+
+    actual = get_fields_type_map(Value2)
+    assert actual == {
+        "v": bool,
+        "v1": int,
+        "v2": float,
+    }
+
+
+def test_get_fields_type_map_non_data_class() -> None:
+    actual = get_fields_type_map(int | None)
+    assert actual == {}
+
+
+def test_get_fields_type_map_not_subscripted() -> None:
+    _T = TypeVar("_T")
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class Xxx(Generic[_T]):
+        xxx: _T
+
+    with pytest.raises(Exception) as e:
+        get_fields_type_map(Xxx)
+
+    assert e.value.args[0] == (
+        "Expected subscripted generic, but got unsubscripted "
+        "<class 'tests.test_generics.test_get_fields_type_map_not_subscripted.<locals>.Xxx'>"
+    )
+
+
+def test_get_fields_class_map() -> None:
+    _T = TypeVar("_T")
+
+    @dataclasses.dataclass()
+    class Base1(Generic[_T]):
+        a: str
+        b: str
+        c: str
+
+    @dataclasses.dataclass()
+    class Base2(Base1[int]):
+        a: str
+        b: str
+        d: str
+        e: str
+
+    @dataclasses.dataclass()
+    class BaseG:
+        f: str
+        g: str
+
+    @dataclasses.dataclass()
+    class Base3(Base2, BaseG):
+        a: str
+        d: str
+        f: str
+        h: str
+
+    actual = get_fields_class_map(Base3)
+    assert actual == {
+        "a": Base3,
+        "b": Base2,
+        "c": Base1,
+        "d": Base3,
+        "e": Base2,
+        "f": Base3,
+        "g": BaseG,
+        "h": Base3,
+    }
+
+
+def test_get_class_type_var_map_inheritance() -> None:
+    _T1 = TypeVar("_T1")
+    _T2 = TypeVar("_T2")
+    _T3 = TypeVar("_T3")
+
+    @dataclasses.dataclass()
+    class NonGeneric:
+        pass
+
+    @dataclasses.dataclass()
+    class Aaa(Generic[_T1, _T2]):
+        pass
+
+    @dataclasses.dataclass()
+    class Bbb(Generic[_T1], Aaa[int, _T1]):
+        pass
+
+    @dataclasses.dataclass()
+    class Ccc(Generic[_T3]):
+        pass
+
+    @dataclasses.dataclass()
+    class Ddd(Generic[_T1, _T2, _T3], Bbb[_T2], Ccc[_T1], NonGeneric):
+        pass
+
+    actual = get_class_type_var_map(Ddd[bool, str, float])
+    assert actual == {
+        Aaa: {
+            _T1: int,
+            _T2: str,
+        },
+        Bbb: {
+            _T1: str,
+        },
+        Ccc: {
+            _T3: bool,
+        },
+        Ddd: {
+            _T1: bool,
+            _T2: str,
+            _T3: float,
+        },
+    }
+
+
+def test_get_class_type_var_map_nesting() -> None:
+    _T1 = TypeVar("_T1")
+    _T2 = TypeVar("_T2")
+    _T3 = TypeVar("_T3")
+
+    @dataclasses.dataclass()
+    class Aaa(Generic[_T1, _T2]):
+        pass
+
+    @dataclasses.dataclass()
+    class Bbb(Generic[_T1]):
+        pass
+
+    @dataclasses.dataclass()
+    class Ccc(Generic[_T1, _T2, _T3], Aaa[Bbb[list[Annotated[_T2, "xxx"]]], _T1 | None]):
+        pass
+
+    actual = get_class_type_var_map(Ccc[bool, str, float])
+    assert actual == {
+        Aaa: {
+            _T1: Bbb[list[Annotated[str, "xxx"]]],
+            _T2: bool | None,
+        },
+        Ccc: {
+            _T1: bool,
+            _T2: str,
+            _T3: float,
+        },
+    }
+
+
+_T1 = TypeVar("_T1")
+_T2 = TypeVar("_T2")
+
+
+class Xxx(Generic[_T1, _T2]):
+    pass
+
+
+class Zzz(Generic[_T1]):
+    pass
+
+
+_TInt = TypeVar("_TInt")
+_TIntNone = TypeVar("_TIntNone")
+_TStr = TypeVar("_TStr")
+_TList = TypeVar("_TList")
+_TDictIntTStr = TypeVar("_TDictIntTStr")
+
+GENERIC_MAP: dict[TypeVar, type[Any] | UnionType] = {
+    _TInt: int,
+    _TIntNone: int | None,
+    _TStr: str,
+    _TList: list,
+    _TDictIntTStr: dict[int, _TStr],  # type: ignore
+}
+
+
+@pytest.mark.parametrize(
+    "t, expected",
+    [
+        (_TIntNone, int | None),
+        (list[_TInt], list[int]),  # type: ignore
+        (list[_TIntNone], list[int | None]),  # type: ignore
+        (List[_TStr], List[str]),  # type: ignore
+        (dict[_TStr, _TInt], dict[str, int]),  # type: ignore
+        (dict[_TStr, list[_TInt]], dict[str, list[int]]),  # type: ignore
+        (_TInt | None, int | None),
+        (bool | None, bool | None),
+        (Union[_TInt, float, bool, _TStr], int | float | bool | str),  # type: ignore
+        (_TInt | float | bool | _TStr, int | float | bool | str),
+        (list[_TInt | None], list[int | None]),  # type: ignore
+        (list[_TList], list[list[Any]]),  # type: ignore
+        (dict[_TInt, _TDictIntTStr], dict[int, dict[int, str]]),  # type: ignore
+        (Annotated[_TStr, "qwe", 123, None], Annotated[str, "qwe", 123, None]),  # type: ignore
+        (Annotated[list[_TStr], "qwe", 123, None], Annotated[list[str], "qwe", 123, None]),  # type: ignore
+        (list[Annotated[list[_TInt], "asd", "zxc"]], list[Annotated[list[int], "asd", "zxc"]]),  # type: ignore
+        (Xxx[list[_TInt], Zzz[_TStr]], Xxx[list[int], Zzz[str]]),  # type: ignore
+    ],
+)
+def test_build_subscripted_type(t: type, expected: type) -> None:
+    actual = build_subscripted_type(t, GENERIC_MAP)
+    assert actual == expected

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -12,7 +12,7 @@ from marshmallow_recipe.generics import (
 )
 
 
-def test_get_fields_type_map_overrides() -> None:
+def test_get_fields_type_map_with_field_override() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class Value1:
         v1: str
@@ -101,6 +101,17 @@ def test_get_fields_type_map_not_subscripted() -> None:
     )
 
 
+def test_get_fields_type_map_for_subscripted() -> None:
+    _T = TypeVar("_T")
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class Xxx(Generic[_T]):
+        xxx: _T
+
+    actual = get_fields_type_map(Xxx[str])
+    assert actual == {"xxx": str}
+
+
 def test_get_fields_class_map() -> None:
     _T = TypeVar("_T")
 
@@ -142,7 +153,7 @@ def test_get_fields_class_map() -> None:
     }
 
 
-def test_get_class_type_var_map_inheritance() -> None:
+def test_get_class_type_var_map_with_inheritance() -> None:
     _T1 = TypeVar("_T1")
     _T2 = TypeVar("_T2")
     _T3 = TypeVar("_T3")
@@ -187,7 +198,7 @@ def test_get_class_type_var_map_inheritance() -> None:
     }
 
 
-def test_get_class_type_var_map_nesting() -> None:
+def test_get_class_type_var_map_with_nesting() -> None:
     _T1 = TypeVar("_T1")
     _T2 = TypeVar("_T2")
     _T3 = TypeVar("_T3")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -652,7 +652,7 @@ def test_nested_default() -> None:
         (True, True, lambda x: x, does_not_raise()),
     ],
 )
-def test_dump_generic_extract_type(
+def test_generic_extract_type_on_dump(
     frozen: bool, slots: bool, get_type: Callable[[type], type | None], context: ContextManager
 ) -> None:
     _TValue = TypeVar("_TValue")
@@ -696,7 +696,7 @@ def test_generic_in_parents() -> None:
     assert mr.load(ChildClass, dumped) == instance
 
 
-def test_generic_reused_type_var() -> None:
+def test_generic_type_var_with_reuse() -> None:
     _T = TypeVar("_T")
 
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
@@ -715,7 +715,7 @@ def test_generic_reused_type_var() -> None:
     assert mr.load(T2[str], dumped) == instance
 
 
-def test_override_field_with_generic() -> None:
+def test_generic_with_field_override() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class Value1:
         v1: str
@@ -745,7 +745,7 @@ def test_override_field_with_generic() -> None:
     assert mr.load(T2[Value2, int], dumped) == instance
 
 
-def test_generic_reuse() -> None:
+def test_generic_origin_reuse() -> None:
     _TItem = TypeVar("_TItem")
 
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -612,6 +612,14 @@ def test_str_strip_whitespaces() -> None:
     assert mr.dump(OptionalStrContainer(value1=None, value2=None)) == {}
 
 
+def test_str_strip_whitespace_with_validation() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class StrContainer:
+        value: Annotated[str | None, mr.str_meta(strip_whitespaces=True, validate=lambda x: len(x) > 0)]
+
+    mr.load(StrContainer, {"value": ""})
+
+
 def test_list_str_strip_whitespaces() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class StrContainer:
@@ -814,11 +822,3 @@ def test_generic_reuse_with_different_args() -> None:
 
     assert dumped == {"items": ["q", "w", "e"]}
     assert mr.load(GenericContainer[str], dumped) == container_str
-
-
-def test_str_strip_whitespace_with_validation() -> None:
-    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-    class StrContainer:
-        value: Annotated[str | None, mr.str_meta(strip_whitespaces=True, validate=lambda x: len(x) > 0)]
-
-    mr.load(StrContainer, {"value": ""})

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -816,39 +816,6 @@ def test_generic_reuse_with_different_args() -> None:
     assert mr.load(GenericContainer[str], dumped) == container_str
 
 
-def test_sdfdfsd():
-    import dataclasses
-    from typing import Generic, TypeVar
-
-    import marshmallow_recipe as mr
-
-    T = TypeVar("T")
-
-    @dataclasses.dataclass()
-    class Regular(Generic[T]):
-        value: T
-
-    mr.dump(Regular[int](value=123))  # it works without explicit cls arg
-
-    @dataclasses.dataclass(frozen=True)
-    class Frozen(Generic[T]):
-        value: T
-
-    mr.dump(Frozen[int], Frozen[int](value=123))  # cls required generic frozen
-
-    @dataclasses.dataclass(slots=True, kw_only=True)
-    class Slots(Generic[T]):
-        value: T
-
-    mr.dump(Slots[int], Slots[int](value=123))
-
-    @dataclasses.dataclass(slots=True)
-    class SlotsNonGeneric(Slots[int]):
-        pass
-
-    mr.dump(SlotsNonGeneric(value=123))  # cls not required
-
-
 def test_str_strip_whitespace_with_validation() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class StrContainer:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -669,12 +669,20 @@ def test_generic_extract_type_on_dump(
 
     instance = Data[int](value=123)
     with context:
-        dumped = mr.dump(instance, cls=get_type(Data[int]))
+        type = get_type(Data[int])
+        if type is None:
+            dumped = mr.dump(instance)
+        else:
+            dumped = mr.dump(type, instance)
         assert dumped == {"value": 123}
 
     instance_many = [Data[int](value=123), Data[int](value=456)]
     with context:
-        dumped = mr.dump_many(instance_many, cls=get_type(Data[int]))
+        type = get_type(Data[int])
+        if type is None:
+            dumped = mr.dump_many(instance_many)
+        else:
+            dumped = mr.dump_many(type, instance_many)
         assert dumped == [{"value": 123}, {"value": 456}]
 
 
@@ -698,12 +706,20 @@ def test_non_generic_extract_type_on_dump(
 
     instance = Data(value=123)
     with context:
-        dumped = mr.dump(instance, cls=get_type(Data))
+        type = get_type(Data)
+        if type is None:
+            dumped = mr.dump(instance)
+        else:
+            dumped = mr.dump(type, instance)
         assert dumped == {"value": 123}
 
     instance_many = [Data(value=123), Data(value=456)]
     with context:
-        dumped = mr.dump_many(instance_many, cls=get_type(Data))
+        type = get_type(Data)
+        if type is None:
+            dumped = mr.dump_many(instance_many)
+        else:
+            dumped = mr.dump_many(type, instance_many)
         assert dumped == [{"value": 123}, {"value": 456}]
 
 
@@ -744,7 +760,7 @@ def test_generic_type_var_with_reuse() -> None:
 
     instance = T2[str](t1=1, t2="2")
 
-    dumped = mr.dump(instance, cls=T2[str])
+    dumped = mr.dump(T2[str], instance)
 
     assert dumped == {"t1": 1, "t2": "2"}
     assert mr.load(T2[str], dumped) == instance
@@ -774,7 +790,7 @@ def test_generic_with_field_override() -> None:
 
     instance = T2[Value2, int](value=Value2(v1="aaa", v2="bbb"), iterable=set([3, 4, 5]))
 
-    dumped = mr.dump(instance, cls=T2[Value2, int])
+    dumped = mr.dump(T2[Value2, int], instance)
 
     assert dumped == {"value": {"v1": "aaa", "v2": "bbb"}, "iterable": [3, 4, 5]}
     assert mr.load(T2[Value2, int], dumped) == instance
@@ -788,13 +804,13 @@ def test_generic_reuse_with_different_args() -> None:
         items: list[_TItem]
 
     container_int = GenericContainer[int](items=[1, 2, 3])
-    dumped = mr.dump(container_int, cls=GenericContainer[int])
+    dumped = mr.dump(GenericContainer[int], container_int)
 
     assert dumped == {"items": [1, 2, 3]}
     assert mr.load(GenericContainer[int], dumped) == container_int
 
     container_str = GenericContainer[str](items=["q", "w", "e"])
-    dumped = mr.dump(container_str, cls=GenericContainer[str])
+    dumped = mr.dump(GenericContainer[str], container_str)
 
     assert dumped == {"items": ["q", "w", "e"]}
     assert mr.load(GenericContainer[str], dumped) == container_str
@@ -818,13 +834,13 @@ def test_sdfdfsd():
     class Frozen(Generic[T]):
         value: T
 
-    mr.dump(Frozen[int](value=123), cls=Frozen[int])  # cls required generic frozen
+    mr.dump(Frozen[int], Frozen[int](value=123))  # cls required generic frozen
 
-    @dataclasses.dataclass(slots=True)
+    @dataclasses.dataclass(slots=True, kw_only=True)
     class Slots(Generic[T]):
         value: T
 
-    mr.dump(Slots[int](value=123), cls=Slots[int])  # cls required for generic with slots
+    mr.dump(Slots[int], Slots[int](value=123))
 
     @dataclasses.dataclass(slots=True)
     class SlotsNonGeneric(Slots[int]):


### PR DESCRIPTION
# Generics support
This PR contains implementation for generics support for both `dump` and `load` methods. I have supported all cases which I met and I could imagine. But may be I missed something. Hope no.

Key points:
- `dump` and `dump_many` were improved to extract actual runtime type for serialization with `_extract_type` function
- `get_fields_type_map` returns dict with actual runtime type for each field accessible by field's name.
- `bake_schema` enumerates all dataclass fields and gets it's type according dict returned by `get_fields_type_map` 
- `get_field_for` mostly was not change because it receives already prepared type to build schema field

I went deeper into Python generics first time and it was not obviously how it works. All issues I met with explanation how I solved them are listed below in **Issues** section. 

All provided code snippets can be executed in Python playground to check how it works:
- https://programiz.pro/ide/python
- https://codapi.org/python/

# Generics in Python
Let we have generic dataclass `class Xxx(Generic[T1, T2])` then:
- `Xxx[int, str]` - subscripted type (closed generic)
- `(int, str)` - tuple with args of `Xxx[int, str]`
- `Xxx` - unsubscripted type (open generic), aka origin
- `(T1, T2)` - tuple with TypeVar items which are params of `Xxx`

```python
import dataclasses
from typing import Generic, TypeVar, get_args, get_origin

T1 = TypeVar("T1")
T2 = TypeVar("T2")

@dataclasses.dataclass()
class Xxx(Generic[T1, T2]):
    pass

assert get_args(Xxx[int, str]) == (int, str)
assert get_origin(Xxx[int, str]) == Xxx
assert Xxx.__parameters__ == (T1, T2)
```

# Issues
## Extracting generic instance type
This is what we should take into account:
- `type(...)` function always returns unsubscripted type
- `__orig_class__` returns subscripted type
- `__orig_class__` does not exist for dataclasses with `frozen=True` or `slots=True`
- `__orig_class__` does not exist for non generic dataclasses

```python
import dataclasses
from typing import Any, Generic, TypeVar, get_origin

T1 = TypeVar("T1")
T2 = TypeVar("T2")

@dataclasses.dataclass()
class Xxx(Generic[T1, T2]):
    pass

@dataclasses.dataclass(slots=True)
class Zzz(Generic[T1, T2]):
    pass

xxx = Xxx[int, str]()
zzz = Zzz[int, str]()

assert type(xxx) == Xxx
assert getattr(xxx, "__orig_class__") == Xxx[int, str]
assert type(zzz) == Zzz
assert hasattr(zzz, "__orig_class__") == False
```

It means in some cases we can not extract subscripted generic type from instance and it should be passed explicitly to dump function. All this stuff implemented in `_extract_type` and tested by `test_generic_extract_type_on_dump`

## Extracting generic dataclass field type

Subscripted type `Xxx[int, str]` is not a dataclass. Only unsubscripted `Xxx` is dataclass. Fields of `Xxx` are also have unsubscripted types. Here are steps how to calculate actual fields types:
1. Get list of args from `Xxx[int, str]`
2. Get origin `Xxx` from `Xxx[int, str]`
3. Ger list of params from `Xxx`
4. Build a map from param to arg
5. Replace field TypeVar with arg from map


```python
import dataclasses
from typing import Generic, TypeVar, get_args, get_origin

T1 = TypeVar("T1")
T2 = TypeVar("T2")

@dataclasses.dataclass()
class Xxx(Generic[T1, T2]):
    t1: T1
    t2: T2

xxx = Xxx[int, str](t1=123, t2="qwe")

cls = xxx.__orig_class__
origin = get_origin(cls)

assert dataclasses.is_dataclass(cls) is False
assert dataclasses.is_dataclass(origin) is True

args = get_args(cls)
params = origin.__parameters__

type_var_map = {param: args[i] for i, param in enumerate(params)}
assert typevars == {T1: int, T2: str}

fields = {f.name: type_var_map[f.type] for f in dataclasses.fields(origin)}
assert fields == {"t1": int, "t2": str}
```

## Class field type with nested generic
Class field type can be more complicated than just `TypeVar`:
- `types.UnionType`
- `Union`
- `Annotated`
- `types.GenericAlias`
- `_GenericAlias`

Subscripted type can be built recursively using the same `type_var_map` from snippet above. It is implemented in `build_subscripted_type` and types recognition can be tested using the code snippet below.

```python
import dataclasses
import types
from typing import Annotated, Generic, TypeVar, Union, get_origin, _GenericAlias

T1 = TypeVar("T1")
T2 = TypeVar("T2")

@dataclasses.dataclass()
class Zzz(Generic[T1, T2]):
    pass

@dataclasses.dataclass()
class Xxx(Generic[T1, T2]):
    type_var: T1
    optional_set: set[T1] | None
    optional_zzz: Zzz[T1, T2] | None
    annotated: Annotated[T1, "meta"]
    generic_set: set[T1]
    generic_zzz: Zzz[T1, T2]

fields = {f.name: f.type for f in dataclasses.fields(Xxx)}

assert isinstance(fields["type_var"], TypeVar)
assert get_origin(fields["optional_set"]) is types.UnionType
assert get_origin(fields["optional_zzz"]) is Union
assert get_origin(fields["annotated"]) is Annotated
assert isinstance(fields["generic_set"], types.GenericAlias)
assert isinstance(fields["generic_zzz"], _GenericAlias)
```

## Inheritance with generics
There are three connected issues to solve 
### Parents or parents of parents can be also generic
- They can be subscripted
  ```python
  class Child(Parent[int]):
      pass
  ```
- They can be subscripted with child generic arg
  ```python
  class Child(Generic[T], Parent[T]):
      pass
  ```
- They can have nested generic
  ```python
  class Child(Generic[T], Parent[list[T]]):
      pass
  ```
To solve this issue we can recursively iterate all parents via `__orig_bases__` and apply `build_subscripted_type` for each parent class with `type_var_map` of child class 

### Class in hierarchy can use same TypeVar as generic param
```python
class Parent(Generic[T]):
    v1: T

class Child(Generic[T], Parent[int]):
    v2: T

instance = Child[str](v1=111, v2="x")
```
`v1` is `int` and `v2` is `str` but for both `field.type` is `T`

So we can not have single `type_var_map` we should have separate maps for each class in hierarchy. All this stuff is implemented in `get_class_type_var_map`. Then we just need to get field's owner class to find its `type_ver_map` and build subscripted field type. BUT... Here is another issue. Check it below.

### Dataclass fields have no owner class reference

It means we need to build a map from field to its owner class. But we need take into account these things:
- `dataclasses.fields(...)` returns all dataclass fields including all fields from all parents
- dataclass fields can be overridden in child dataclasses including generic override
- all dataclass fields have unique names even if they were overridden
- every field override will have its own descriptor in child dataclass

To build `fields_class_map` can be used the same approach as in `dataclasses` module using enumeration of reversed `__mro__`. Field name can be used as a key as it is unique. This stuff is implemented in `get_fields_class_map` function. The snippet below explains how it works and can be used to play with it.

```python
import dataclasses

@dataclasses.dataclass()
class Parent():
    v1: str
    v2: str

@dataclasses.dataclass()
class Child(Parent):
    v2: str
    v3: str

fields_p = dataclasses.fields(Parent)
fields_c = dataclasses.fields(Child)

assert [f.name for f in fields_p] == ["v1", "v2"]
assert [f.name for f in fields_c] == ["v1", "v2", "v3"]

assert fields_c[0] == fields_p[0]  # same descriptor for v1
assert fields_c[1] != fields_p[1]  # new descriptor for overridden v2

fields: dict[str, dataclasses.Field] = {}
classes: dict[str, type] = {}

target = Child
for cls in (*target.__mro__[-1:0:-1], target):  # same as dataclass collects fields
    if not dataclasses.is_dataclass(cls):
        continue
    for field in dataclasses.fields(cls):
        if fields.get(field.name) != field:  # new field detected including override
            fields[field.name] = field
            classes[field.name] = cls

assert classes == {
    "v1": Parent,
    "v2": Child,
    "v3": Child
}
```
## That's it
It works!
