### PR TITLE
Preserve declaration order on dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+* [Preserve declaration order](https://github.com/anna-money/marshmallow-recipe/pull/164)
+
+
 ## v0.0.41(2024-11-01)
 
 * [Int enum support](https://github.com/anna-money/marshmallow-recipe/pull/161)

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -44,6 +44,8 @@ class _SchemaTypeKey:
 
 _T = TypeVar("_T")
 _MARSHMALLOW_VERSION_MAJOR = int(m.__version__.split(".")[0])
+_MARSHMALLOW_VERSION_MINOR = int(m.__version__.split(".")[1])
+
 _schema_types: dict[_SchemaTypeKey, type[m.Schema]] = {}
 
 
@@ -280,7 +282,10 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
         class _Schema(m.Schema):
             class Meta:  # type: ignore
                 unknown = m.EXCLUDE  # type: ignore
-                ordered = True  # type: ignore
+
+            @property
+            def set_class(self) -> type:
+                return m.schema.OrderedSet
 
             @m.post_dump
             def remove_none_values(self, data: dict[str, Any], **_: Any) -> dict[str, Any]:
@@ -307,6 +312,10 @@ else:
         class _Schema(m.Schema):  # type: ignore
             class Meta:  # type: ignore
                 ordered = True  # type: ignore
+
+            @property
+            def set_class(self) -> type:
+                return m.schema.OrderedSet
 
             @m.post_dump  # type: ignore
             def remove_none_values(self, data: dict[str, Any]) -> dict[str, Any]:

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -309,9 +309,6 @@ else:
 
     def _get_base_schema(cls: type, none_value_handling: NoneValueHandling) -> type[m.Schema]:
         class _Schema(m.Schema):  # type: ignore
-            class Meta:  # type: ignore
-                ordered = True  # type: ignore
-
             @property
             def set_class(self) -> type:
                 return m.schema.OrderedSet

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -284,7 +284,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
             @property
             def set_class(self) -> type:
-                return m.schema.OrderedSet
+                return m.schema.OrderedSet  # type: ignore
 
             @m.post_dump
             def remove_none_values(self, data: dict[str, Any], **_: Any) -> dict[str, Any]:
@@ -311,7 +311,7 @@ else:
         class _Schema(m.Schema):  # type: ignore
             @property
             def set_class(self) -> type:
-                return m.schema.OrderedSet
+                return m.schema.OrderedSet  # type: ignore
 
             @m.post_dump  # type: ignore
             def remove_none_values(self, data: dict[str, Any]) -> dict[str, Any]:

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -280,6 +280,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
         class _Schema(m.Schema):
             class Meta:  # type: ignore
                 unknown = m.EXCLUDE  # type: ignore
+                ordered = True  # type: ignore
 
             @m.post_dump
             def remove_none_values(self, data: dict[str, Any], **_: Any) -> dict[str, Any]:
@@ -304,6 +305,9 @@ else:
 
     def _get_base_schema(cls: type, none_value_handling: NoneValueHandling) -> type[m.Schema]:
         class _Schema(m.Schema):  # type: ignore
+            class Meta:  # type: ignore
+                ordered = True  # type: ignore
+
             @m.post_dump  # type: ignore
             def remove_none_values(self, data: dict[str, Any]) -> dict[str, Any]:
                 if none_value_handling == NoneValueHandling.IGNORE:

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -44,7 +44,6 @@ class _SchemaTypeKey:
 
 _T = TypeVar("_T")
 _MARSHMALLOW_VERSION_MAJOR = int(m.__version__.split(".")[0])
-_MARSHMALLOW_VERSION_MINOR = int(m.__version__.split(".")[1])
 
 _schema_types: dict[_SchemaTypeKey, type[m.Schema]] = {}
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,0 +1,11 @@
+import marshmallow_recipe as mr
+import dataclasses
+
+
+def test_order():
+    @dataclasses.dataclass
+    class A:
+        a: int
+        b: int
+
+    assert [name for name in mr.dump(A(a=1, b=2))] == ["a", "b"]

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,5 +1,6 @@
-import marshmallow_recipe as mr
 import dataclasses
+
+import marshmallow_recipe as mr
 
 
 def test_order():


### PR DESCRIPTION
As it is described here, https://github.com/marshmallow-code/marshmallow/pull/1896, changing set_class to OrderedSet might affect only schema instantiation, so has a minimal perfomance impact. 