### PR TITLE
Fix strip whitespaces with validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.44(2025-02-04)
+
+* [Fix strip whitespaces with validation](https://github.com/anna-money/marshmallow-recipe/pull/168)
+
+
 ## v0.0.43(2024-11-11)
 
 * [Fix python_requires to be >=3.11](https://github.com/anna-money/marshmallow-recipe/commit/ab1eca29324569dbcc712f589078eee9980f9b10)

--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -103,7 +103,7 @@ __all__: tuple[str, ...] = (
     "get_validation_field_errors",
 )
 
-__version__ = "0.0.43"
+__version__ = "0.0.44"
 
 version = f"{__version__}, Python {sys.version}"
 

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -630,10 +630,10 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
             return result
 
-        def _validate(self, output: Any) -> None:
-            if self.allow_none and output is None:
+        def _validate(self, value: Any) -> None:
+            if self.allow_none and value is None:
                 return
-            super()._validate(output)
+            super()._validate(value)
 
     StrField = StrFieldV3
 
@@ -844,10 +844,10 @@ else:
 
             return result
 
-        def _validate(self, output: Any) -> None:
-            if self.allow_none and output is None:
+        def _validate(self, value: Any) -> None:
+            if self.allow_none and value is None:
                 return
-            super()._validate(output)
+            super()._validate(value)
 
     StrField = StrFieldV2
 

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -630,6 +630,11 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
             return result
 
+        def _validate(self, output: Any) -> None:
+            if self.allow_none and output is None:
+                return
+            super()._validate(output)
+
     StrField = StrFieldV3
 
     class DateTimeFieldV3(m.fields.DateTime):
@@ -838,6 +843,11 @@ else:
                     result = self.post_load(result)
 
             return result
+
+        def _validate(self, output: Any) -> None:
+            if self.allow_none and output is None:
+                return
+            super()._validate(output)
 
     StrField = StrFieldV2
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -627,3 +627,11 @@ def test_nested_default() -> None:
         int_container: IntContainer = dataclasses.field(default_factory=IntContainer)
 
     assert mr.load(RootContainer, {}) == RootContainer()
+
+
+def test_str_strip_whitespace_with_validation() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class StrContainer:
+        value: Annotated[str | None, mr.str_meta(strip_whitespaces=True, validate=lambda x: len(x) > 0)]
+
+    mr.load(StrContainer, {"value": ""})


### PR DESCRIPTION
Otherwise, this fails.

```
@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
    class StrContainer:
        value: Annotated[str | None, mr.str_meta(strip_whitespaces=True, validate=lambda x: len(x) > 0)]

    mr.load(StrContainer, {"value": ""})
```