### PR TITLE
Add None type for places in decimal_metadata

### DIFF
--- a/marshmallow_recipe/metadata.py
+++ b/marshmallow_recipe/metadata.py
@@ -70,7 +70,7 @@ def str_metadata(
 def decimal_metadata(
     *,
     name: str = MISSING,
-    places: int = MISSING,
+    places: int | None = MISSING,
     as_string: bool = MISSING,
     validate: ValidationFunc | collections.abc.Sequence[ValidationFunc] | None = None,
 ) -> Metadata:


### PR DESCRIPTION
This is necessary if I don't want to limit the places. Now, if use MISSING, I have a places = 2 by default.