### PR TITLE
Make Metadata hashable

### DIFF
--- a/marshmallow_recipe/metadata.py
+++ b/marshmallow_recipe/metadata.py
@@ -1,12 +1,12 @@
 import collections.abc
-from typing import Any, Hashable, TypeGuard, final
+from typing import Any, TypeGuard, final
 
 from .missing import MISSING
 from .validation import ValidationFunc
 
 
 @final
-class Metadata(collections.abc.Mapping[str, Any], Hashable):
+class Metadata(collections.abc.Mapping[str, Any], collections.abc.Hashable):
     __slots__ = ("__values",)
 
     def __init__(self, values: collections.abc.Mapping[str, Any]) -> None:

--- a/marshmallow_recipe/metadata.py
+++ b/marshmallow_recipe/metadata.py
@@ -7,11 +7,10 @@ from .validation import ValidationFunc
 
 @final
 class Metadata(collections.abc.Mapping[str, Any], Hashable):
-    __slots__ = ("__values", "__hash")
+    __slots__ = ("__values",)
 
     def __init__(self, values: collections.abc.Mapping[str, Any]) -> None:
         self.__values = values
-        self.__hash: int | None = None
 
     def __getitem__(self, key: str) -> Any:
         return self.__values[key]
@@ -29,17 +28,13 @@ class Metadata(collections.abc.Mapping[str, Any], Hashable):
         return str(self.__values)
 
     def __hash__(self) -> int:
-        if self.__hash is None:
-            h = 0
-            for key in sorted(self.__values):
-                h ^= hash(key)
-            self.__hash = h ^ len(self.__values)
-        return self.__hash
+        result = 0
+        for key in self.__values:
+            result ^= hash(key)
+        return result ^ len(self.__values)
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, Metadata):
-            return self.__values == other.__values
-        return False
+        return isinstance(other, Metadata) and self.__values == other.__values
 
 
 EMPTY_METADATA = Metadata({})

--- a/marshmallow_recipe/metadata.py
+++ b/marshmallow_recipe/metadata.py
@@ -1,16 +1,17 @@
 import collections.abc
-from typing import Any, TypeGuard, final
+from typing import Any, Hashable, TypeGuard, final
 
 from .missing import MISSING
 from .validation import ValidationFunc
 
 
 @final
-class Metadata(collections.abc.Mapping[str, Any]):
-    __slots__ = ("__values",)
+class Metadata(collections.abc.Mapping[str, Any], Hashable):
+    __slots__ = ("__values", "__hash")
 
     def __init__(self, values: collections.abc.Mapping[str, Any]) -> None:
         self.__values = values
+        self.__hash: int | None = None
 
     def __getitem__(self, key: str) -> Any:
         return self.__values[key]
@@ -26,6 +27,19 @@ class Metadata(collections.abc.Mapping[str, Any]):
 
     def __str__(self) -> str:
         return str(self.__values)
+
+    def __hash__(self) -> int:
+        if self.__hash is None:
+            h = 0
+            for key in sorted(self.__values):
+                h ^= hash(key)
+            self.__hash = h ^ len(self.__values)
+        return self.__hash
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, Metadata):
+            return self.__values == other.__values
+        return False
 
 
 EMPTY_METADATA = Metadata({})

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,25 @@
+import marshmallow_recipe as mr
+
+
+def test_metadata_1() -> None:
+    metadata1 = mr.Metadata(dict(a=1, b=2))
+    metadata2 = mr.Metadata(dict(b=2, a=1))
+
+    assert hash(metadata1) == hash(metadata2)
+    assert metadata1 == metadata2
+
+
+def test_metadata_2() -> None:
+    metadata1 = mr.Metadata(dict(a=1, b=1))
+    metadata2 = mr.Metadata(dict(b=2, a=2))
+
+    assert hash(metadata1) == hash(metadata2)
+    assert metadata1 != metadata2
+
+
+def test_metadata_3() -> None:
+    metadata1 = mr.Metadata(dict(a=1, b=1))
+    metadata2 = mr.Metadata(dict(b=2, c=2))
+
+    assert hash(metadata1) != hash(metadata2)
+    assert metadata1 != metadata2

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,7 +1,7 @@
 import marshmallow_recipe as mr
 
 
-def test_metadata_1() -> None:
+def test_metadata_different_keys_order() -> None:
     metadata1 = mr.Metadata(dict(a=1, b=2))
     metadata2 = mr.Metadata(dict(b=2, a=1))
 
@@ -9,7 +9,7 @@ def test_metadata_1() -> None:
     assert metadata1 == metadata2
 
 
-def test_metadata_2() -> None:
+def test_metadata_not_equal_same_hash() -> None:
     metadata1 = mr.Metadata(dict(a=1, b=1))
     metadata2 = mr.Metadata(dict(b=2, a=2))
 
@@ -17,7 +17,7 @@ def test_metadata_2() -> None:
     assert metadata1 != metadata2
 
 
-def test_metadata_3() -> None:
+def test_metadata_not_equal() -> None:
     metadata1 = mr.Metadata(dict(a=1, b=1))
     metadata2 = mr.Metadata(dict(b=2, c=2))
 


### PR DESCRIPTION
Dataclasses fields types are often used in dictionaries like key, so when using annotated we can receive the following:
```
def __hash__(self):
>       return hash((self.__origin__, self.__metadata__))
E       TypeError: unhashable type: 'Metadata'
```