### PR TITLE
Support unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.53(2025-06-26)
+
+* [Support unions](https://github.com/anna-money/marshmallow-recipe/pull/182)
+
+
 ## v0.0.52(2025-05-21)
 
 * [Support upper snake case](https://github.com/anna-money/marshmallow-recipe/pull/183)

--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -3,7 +3,7 @@ import re
 import sys
 
 from .bake import bake_schema, get_field_for
-from .fields import DateTimeField, DictField, EnumField, FrozenSetField, SetField, StrField, TupleField
+from .fields import DateTimeField, DictField, EnumField, FrozenSetField, SetField, StrField, TupleField, UnionField
 from .hooks import add_pre_load, pre_load
 from .metadata import (
     EMPTY_METADATA,
@@ -63,6 +63,7 @@ __all__: tuple[str, ...] = (
     "SetField",
     "StrField",
     "TupleField",
+    "UnionField",
     # metadata.py
     "Metadata",
     "EMPTY_METADATA",

--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -114,7 +114,7 @@ __all__: tuple[str, ...] = (
     "get_validation_field_errors",
 )
 
-__version__ = "0.0.52"
+__version__ = "0.0.53a1"
 
 version = f"{__version__}, Python {sys.version}"
 

--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -114,7 +114,7 @@ __all__: tuple[str, ...] = (
     "get_validation_field_errors",
 )
 
-__version__ = "0.0.53a1"
+__version__ = "0.0.53"
 
 version = f"{__version__}, Python {sys.version}"
 

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -185,7 +185,6 @@ def get_field_for(
                 **metadata,
             ),
             type_guards=unsubscripted_type,  # type: ignore
-            is_dataclass=True,
         )
 
     if (origin := get_origin(t)) is not None:

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -145,7 +145,6 @@ def get_field_for(
         required = True
         allow_none = False
 
-    #
     if underlying_union_types is not None:
         effective_underlying_union_types = [t for t in underlying_union_types if t is not types.NoneType]
         if not effective_underlying_union_types:
@@ -153,16 +152,15 @@ def get_field_for(
         if len(effective_underlying_union_types) == 1:
             t = effective_underlying_union_types[0]
         else:
-            underlying_union_fields = []
-            for underlying_type in underlying_union_types:
-                underlying_union_fields.append(
-                    get_field_for(
-                        underlying_type,
-                        metadata=metadata,
-                        naming_case=naming_case,
-                        none_value_handling=none_value_handling,
-                    )
+            underlying_union_fields = {}
+            for underlying_type in effective_underlying_union_types:
+                underlying_union_fields[underlying_type] = get_field_for(
+                    underlying_type,
+                    metadata=EMPTY_METADATA,
+                    naming_case=naming_case,
+                    none_value_handling=none_value_handling,
                 )
+
             return union_field(
                 fields=underlying_union_fields,
                 required=required,

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -154,8 +154,8 @@ def get_field_for(
         else:
             underlying_union_fields = {}
             for underlying_type in effective_underlying_union_types:
-                affective_underlying_type = get_origin(underlying_type) or underlying_type
-                underlying_union_fields[affective_underlying_type] = get_field_for(
+                effective_underlying_type = get_origin(underlying_type) or underlying_type
+                underlying_union_fields[effective_underlying_type] = get_field_for(
                     underlying_type,
                     metadata=EMPTY_METADATA,
                     naming_case=naming_case,

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -154,8 +154,7 @@ def get_field_for(
         else:
             underlying_union_fields = {}
             for underlying_type in effective_underlying_union_types:
-                effective_underlying_type = get_origin(underlying_type) or underlying_type
-                underlying_union_fields[effective_underlying_type] = get_field_for(
+                underlying_union_fields[underlying_type] = get_field_for(
                     underlying_type,
                     metadata=EMPTY_METADATA,
                     naming_case=naming_case,

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -30,7 +30,7 @@ from .fields import (
     tuple_field,
     union_field,
     uuid_field,
-    validate_value,
+    with_type_checks_on_serialize,
 )
 from .generics import TypeLike, get_fields_type_map
 from .hooks import get_pre_loads
@@ -177,7 +177,7 @@ def get_field_for(
         return enum_field(enum_type=t, required=required, allow_none=allow_none, **metadata)
 
     if (unsubscripted_type := get_origin(t) or t) and dataclasses.is_dataclass(unsubscripted_type):
-        return validate_value(
+        return with_type_checks_on_serialize(
             nested_field(
                 bake_schema(cast(type, t), naming_case=naming_case, none_value_handling=none_value_handling),
                 required=required,
@@ -197,7 +197,7 @@ def get_field_for(
             else:
                 item_field_metadata = EMPTY_METADATA
 
-            return validate_value(
+            return with_type_checks_on_serialize(
                 list_field(
                     get_field_for(
                         arguments[0],
@@ -219,7 +219,7 @@ def get_field_for(
             else:
                 item_field_metadata = EMPTY_METADATA
 
-            return validate_value(
+            return with_type_checks_on_serialize(
                 set_field(
                     get_field_for(
                         arguments[0],
@@ -241,7 +241,7 @@ def get_field_for(
             else:
                 item_field_metadata = EMPTY_METADATA
 
-            return validate_value(
+            return with_type_checks_on_serialize(
                 frozen_set_field(
                     get_field_for(
                         arguments[0],
@@ -277,7 +277,7 @@ def get_field_for(
                     none_value_handling=none_value_handling,
                 )
             )
-            return validate_value(
+            return with_type_checks_on_serialize(
                 dict_field(keys_field, values_field, required=required, allow_none=allow_none, **metadata),
                 type_guards=dict,
             )
@@ -289,7 +289,7 @@ def get_field_for(
             else:
                 item_field_metadata = EMPTY_METADATA
 
-            return validate_value(
+            return with_type_checks_on_serialize(
                 tuple_field(
                     get_field_for(
                         arguments[0],
@@ -320,7 +320,9 @@ def get_field_for(
 
     if t in _SIMPLE_TYPE_FIELD_FACTORIES:
         field_factory = _SIMPLE_TYPE_FIELD_FACTORIES[t]
-        return validate_value(field_factory(required=required, allow_none=allow_none, **metadata), type_guards=t)
+        return with_type_checks_on_serialize(
+            field_factory(required=required, allow_none=allow_none, **metadata), type_guards=t
+        )
 
     raise ValueError(f"Unsupported {t=}")
 

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -154,7 +154,8 @@ def get_field_for(
         else:
             underlying_union_fields = {}
             for underlying_type in effective_underlying_union_types:
-                underlying_union_fields[underlying_type] = get_field_for(
+                affective_underlying_type = get_origin(underlying_type) or underlying_type
+                underlying_union_fields[affective_underlying_type] = get_field_for(
                     underlying_type,
                     metadata=EMPTY_METADATA,
                     naming_case=naming_case,

--- a/marshmallow_recipe/bake.py
+++ b/marshmallow_recipe/bake.py
@@ -363,6 +363,8 @@ else:
 
             @m.pre_load  # type: ignore
             def pre_load(self, data: dict[str, Any]) -> Any:
+                if not isinstance(data, dict):  # type: ignore
+                    return data
                 # Exclude unknown fields to prevent possible value overlapping
                 known_fields = {field.load_from or field.name for field in self.fields.values()}  # type: ignore
                 result = {key: value for key, value in data.items() if key in known_fields}

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -854,7 +854,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
         def _deserialize(self, value: Any, attr: Any, data: Any, **kwargs: Any) -> Any:
             errors = []
-            for type, field in reversed(self.fields.items()):
+            for type, field in self.fields.items():
                 try:
                     result = field.deserialize(value, attr, data, **kwargs)
                     if not isinstance(result, type):
@@ -1182,7 +1182,7 @@ else:
 
         def _deserialize(self, value: Any, attr: Any, data: Any, **kwargs: Any) -> Any:
             errors = []
-            for type, field in reversed(self.fields.items()):
+            for type, field in self.fields.items():
                 try:
                     result = field.deserialize(value, attr, data, **kwargs)
                     if not isinstance(result, type):

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -1171,9 +1171,7 @@ else:
 
         def _serialize(self, value: Any, attr: Any, obj: Any, **kwargs: Any) -> Any:
             errors = []
-            for type, field in self.fields.items():
-                if not isinstance(value, type):
-                    continue
+            for field in self.fields.values():
                 try:
                     return field._serialize(value, attr, obj, **kwargs)
                 except m.ValidationError as e:
@@ -1182,12 +1180,9 @@ else:
 
         def _deserialize(self, value: Any, attr: Any, data: Any, **kwargs: Any) -> Any:
             errors = []
-            for type, field in self.fields.items():
+            for field in self.fields.values():
                 try:
-                    result = field.deserialize(value, attr, data, **kwargs)
-                    if not isinstance(result, type):
-                        errors.append(f"Expected type {type}, got {type(result)}")
-                    return result
+                    return field.deserialize(value, attr, data, **kwargs)
                 except m.ValidationError as exc:
                     errors.append(exc.messages)
             raise m.ValidationError(message=errors, field_name=attr)

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -841,7 +841,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
             self.fields = fields
             super().__init__(**kwargs)
 
-        def _serialize(self, value: Any, attr: str, obj: str, **kwargs: Any) -> Any:
+        def _serialize(self, value: Any, attr: Any, obj: Any, **kwargs: Any) -> Any:
             errors = []
             for type, field in self.fields.items():
                 if not isinstance(value, type):
@@ -1169,7 +1169,7 @@ else:
             self.fields = fields
             super().__init__(**kwargs)
 
-        def _serialize(self, value: Any, attr: str, obj: str, **kwargs: Any) -> Any:
+        def _serialize(self, value: Any, attr: Any, obj: Any, **kwargs: Any) -> Any:
             errors = []
             for type, field in self.fields.items():
                 if not isinstance(value, type):

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -635,7 +635,7 @@ UnionField: type[m.fields.Field]
 
 if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
-    def validate_value_v3(field: TField, type_guards: type | tuple[type, ...]) -> TField:
+    def with_type_checks_on_serialize_v3(field: TField, type_guards: type | tuple[type, ...]) -> TField:
         fail_key = "invalid" if "invalid" in field.default_error_messages else "validator_failed"
 
         old = field._serialize  # type: ignore
@@ -649,7 +649,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
         return field
 
-    validate_value = validate_value_v3
+    with_type_checks_on_serialize = with_type_checks_on_serialize_v3
 
     def data_key_fields(name: str | None) -> collections.abc.Mapping[str, Any]:
         if name is None:
@@ -882,7 +882,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
     UnionField = UnionFieldV3
 else:
 
-    def validate_value_v2(field: TField, type_guards: type | tuple[type, ...]) -> TField:
+    def with_type_checks_on_serialize_v2(field: TField, type_guards: type | tuple[type, ...]) -> TField:
         fail_key = "invalid" if "invalid" in field.default_error_messages else "validator_failed"
 
         old = field._serialize  # type: ignore
@@ -896,7 +896,7 @@ else:
 
         return field
 
-    validate_value = validate_value_v2
+    with_type_checks_on_serialize = with_type_checks_on_serialize_v2
 
     dateutil_tz_utc_cls: type[datetime.tzinfo] | None
     try:

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -651,7 +651,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
                 or is_dataclass
                 and not dataclasses.is_dataclass(value)
             ):
-                raise self.make_error(fail_key)
+                raise self.make_error(fail_key)  # type: ignore
             return old(value, attr, obj, **kwargs)
 
         field._serialize = types.MethodType(_serialize_with_validate, field)  # type: ignore
@@ -907,7 +907,7 @@ else:
                 or is_dataclass
                 and not dataclasses.is_dataclass(value)
             ):
-                self.fail(fail_key)
+                self.fail(fail_key)  # type: ignore
             return old(value, attr, obj, **kwargs)
 
         field._serialize = types.MethodType(_serialize_with_validate, field)  # type: ignore

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -146,24 +146,24 @@ def int_field(
     **_: Any,
 ) -> m.fields.Field:
     if default is m.missing:
-        return m.fields.Int(
+        field = m.fields.Int(
             allow_none=allow_none,
             validate=validate,
             **default_fields(m.missing),
             **data_key_fields(name),
         )
-
-    if required:
+    elif required:
         if default is None:
             raise ValueError("Default value cannot be none")
-        return m.fields.Int(required=True, allow_none=allow_none, validate=validate, **data_key_fields(name))
-
-    return m.fields.Int(
-        allow_none=allow_none,
-        validate=validate,
-        **(default_fields(None) if default is dataclasses.MISSING else {}),
-        **data_key_fields(name),
-    )
+        field = m.fields.Int(required=True, allow_none=allow_none, validate=validate, **data_key_fields(name))
+    else:
+        field = m.fields.Int(
+            allow_none=allow_none,
+            validate=validate,
+            **(default_fields(None) if default is dataclasses.MISSING else {}),
+            **data_key_fields(name),
+        )
+    return with_type_checks_on_validated(field, (int, str))
 
 
 def float_field(
@@ -651,6 +651,25 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     with_type_checks_on_serialize = with_type_checks_on_serialize_v3
 
+    def with_type_checks_on_validated_v3(field: TField, type_guards: type | tuple[type, ...]) -> TField:
+        if not hasattr(field, "_validated"):
+            raise TypeError("Field doesn't have _validated method")
+
+        fail_key = "invalid" if "invalid" in field.default_error_messages else "validator_failed"
+
+        old = field._validated  # type: ignore
+
+        def _validated(self: TField, value: Any) -> Any:
+            if not isinstance(value, type_guards):
+                raise self.make_error(fail_key)  # type: ignore
+            return old(value)
+
+        field._validated = types.MethodType(_validated, field)  # type: ignore
+
+        return field
+
+    with_type_checks_on_validated = with_type_checks_on_validated_v3
+
     def data_key_fields(name: str | None) -> collections.abc.Mapping[str, Any]:
         if name is None:
             return {}
@@ -897,6 +916,25 @@ else:
         return field
 
     with_type_checks_on_serialize = with_type_checks_on_serialize_v2
+
+    def with_type_checks_on_validated_v2(field: TField, type_guards: type | tuple[type, ...]) -> TField:
+        if not hasattr(field, "_validated"):
+            raise TypeError("Field doesn't have _validated method")
+
+        fail_key = "invalid" if "invalid" in field.default_error_messages else "validator_failed"
+
+        old = field._validated  # type: ignore
+
+        def _validated(self: TField, value: Any) -> Any:
+            if value not in (None, m.missing) and not isinstance(value, type_guards):
+                raise self.fail(fail_key)  # type: ignore
+            return old(value)
+
+        field._validated = types.MethodType(_validated, field)  # type: ignore
+
+        return field
+
+    with_type_checks_on_validated = with_type_checks_on_validated_v2
 
     dateutil_tz_utc_cls: type[datetime.tzinfo] | None
     try:

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -635,22 +635,13 @@ UnionField: type[m.fields.Field]
 
 if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
-    def validate_value_v3(
-        field: TField,
-        type_guards: type | tuple[type, ...] | None = None,
-        is_dataclass: bool = False,
-    ) -> TField:
+    def validate_value_v3(field: TField, type_guards: type | tuple[type, ...]) -> TField:
         fail_key = "invalid" if "invalid" in field.default_error_messages else "validator_failed"
 
         old = field._serialize  # type: ignore
 
         def _serialize_with_validate(self: TField, value: Any, attr: Any, obj: Any, **kwargs: Any) -> Any:
-            if value is not None and (
-                type_guards is not None
-                and not isinstance(value, type_guards)
-                or is_dataclass
-                and not dataclasses.is_dataclass(value)
-            ):
+            if value is not None and not isinstance(value, type_guards):
                 raise self.make_error(fail_key)  # type: ignore
             return old(value, attr, obj, **kwargs)
 
@@ -891,22 +882,13 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
     UnionField = UnionFieldV3
 else:
 
-    def validate_value_v2(
-        field: TField,
-        type_guards: type | tuple[type, ...] | None = None,
-        is_dataclass: bool = False,
-    ) -> TField:
+    def validate_value_v2(field: TField, type_guards: type | tuple[type, ...]) -> TField:
         fail_key = "invalid" if "invalid" in field.default_error_messages else "validator_failed"
 
         old = field._serialize  # type: ignore
 
         def _serialize_with_validate(self: TField, value: Any, attr: Any, obj: Any, **kwargs: Any) -> Any:
-            if value is not None and (
-                type_guards is not None
-                and not isinstance(value, type_guards)
-                or is_dataclass
-                and not dataclasses.is_dataclass(value)
-            ):
+            if value is not None and not isinstance(value, type_guards):
                 self.fail(fail_key)  # type: ignore
             return old(value, attr, obj, **kwargs)
 

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -4,7 +4,7 @@ import dataclasses
 import datetime
 import enum
 import importlib.metadata
-from typing import Any, Mapping
+from typing import Any
 
 import marshmallow as m
 import marshmallow.validate
@@ -837,7 +837,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
     DictField = m.fields.Dict
 
     class UnionFieldV3(m.fields.Field):
-        def __init__(self, fields: Mapping[type, m.fields.Field], **kwargs: Any):
+        def __init__(self, fields: dict[type, m.fields.Field], **kwargs: Any):
             self.fields = fields
             super().__init__(**kwargs)
 
@@ -1165,7 +1165,7 @@ else:
     DictField = TypedDict
 
     class UnionFieldV2(m.fields.Field):
-        def __init__(self, fields: Mapping[type, m.fields.Field], **kwargs: Any):
+        def __init__(self, fields: dict[type, m.fields.Field], **kwargs: Any):
             self.fields = fields
             super().__init__(**kwargs)
 
@@ -1191,6 +1191,5 @@ else:
                 except m.ValidationError as exc:
                     errors.append(exc.messages)
             raise m.ValidationError(message=errors, field_name=attr)
-
 
     UnionField = UnionFieldV2

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -961,7 +961,7 @@ EMPTY_SCHEMA = m.Schema()
             int | str,
             {},
             mr.UnionField(
-                fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
+                fields=[m.fields.Int(required=True), mr.StrField(required=True)],
                 required=True,
             ),
         ),
@@ -969,7 +969,7 @@ EMPTY_SCHEMA = m.Schema()
             int | str,
             mr.meta(name="i"),
             mr.UnionField(
-                fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
+                fields=[m.fields.Int(required=True), mr.StrField(required=True)],
                 required=True,
                 **data_key_fields("i"),
             ),
@@ -978,7 +978,7 @@ EMPTY_SCHEMA = m.Schema()
             int | str | None,
             {},
             mr.UnionField(
-                fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
+                fields=[m.fields.Int(required=True), mr.StrField(required=True)],
                 allow_none=True,
                 **default_fields(None),
             ),
@@ -987,7 +987,7 @@ EMPTY_SCHEMA = m.Schema()
             int | str | None,
             mr.meta(name="i"),
             mr.UnionField(
-                fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
+                fields=[m.fields.Int(required=True), mr.StrField(required=True)],
                 allow_none=True,
                 **default_fields(None),
                 **data_key_fields("i"),

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -966,12 +966,31 @@ EMPTY_SCHEMA = m.Schema()
             ),
         ),
         (
+            int | str,
+            mr.meta(name="i"),
+            mr.UnionField(
+                fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
+                required=True,
+                **data_key_fields("i"),
+            ),
+        ),
+        (
             int | str | None,
             {},
             mr.UnionField(
                 fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
                 allow_none=True,
                 **default_fields(None),
+            ),
+        ),
+        (
+            int | str | None,
+            mr.meta(name="i"),
+            mr.UnionField(
+                fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
+                allow_none=True,
+                **default_fields(None),
+                **data_key_fields("i"),
             ),
         ),
     ],

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -970,8 +970,8 @@ EMPTY_SCHEMA = m.Schema()
             {},
             mr.UnionField(
                 fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
-                required=False,
                 allow_none=True,
+                **default_fields(None),
             ),
         ),
     ],

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -956,6 +956,24 @@ EMPTY_SCHEMA = m.Schema()
                 **data_key_fields("i"),
             ),
         ),
+        # unions...
+        (
+            int | str,
+            {},
+            mr.UnionField(
+                fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
+                required=True,
+            ),
+        ),
+        (
+            int | str | None,
+            {},
+            mr.UnionField(
+                fields={int: m.fields.Int(required=True), str: mr.StrField(required=True)},
+                required=False,
+                allow_none=True,
+            ),
+        ),
     ],
 )
 def test_get_field_for(type: type, metadata: dict[str, Any], field: m.fields.Field) -> None:

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -26,6 +26,7 @@ def test_simple_types() -> None:
         bool_field: bool = mr.MISSING
         float_field: float = mr.MISSING
         enum_field: EnumType = mr.MISSING
+        int_float_union: int | float = mr.MISSING
 
     dumped = mr.dump(TypeWithMissing())
     assert dumped == {}

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -27,6 +27,7 @@ def test_simple_types() -> None:
         float_field: float = mr.MISSING
         enum_field: EnumType = mr.MISSING
         int_float_union: int | float = mr.MISSING
+        str_bool_union: str | bool = mr.MISSING
 
     dumped = mr.dump(TypeWithMissing())
     assert dumped == {}

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -916,6 +916,7 @@ def test_union_priority_str_int() -> None:
     assert dumped == {"value": "abc"}
     assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value="abc")
 
+
 def test_union_str_parametrised_dict() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class ContainerStrDict:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -27,6 +27,7 @@ import pytest
 import marshmallow_recipe as mr
 
 NewInt = NewType("NewInt", int)
+T = TypeVar("T")
 
 
 class Parity(str, enum.Enum):
@@ -911,7 +912,7 @@ def test_union_priority_str_int() -> None:
     assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value=123)
 
 
-def test_union_str_or_dict() -> None:
+def test_union_str_parametrised_dict() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class ContainerStrDict:
         value: str | dict[str, Any]
@@ -925,3 +926,91 @@ def test_union_str_or_dict() -> None:
     dumped = mr.dump(ContainerStrDict, instance)
     assert dumped == {"value": {"key": "value"}}
     assert mr.load(ContainerStrDict, dumped) == instance
+
+
+def test_union_parametrised_dict_str() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerDictStr:
+        value: dict[str, Any] | str
+
+    instance = ContainerDictStr(value="str")
+    dumped = mr.dump(ContainerDictStr, instance)
+    assert dumped == {"value": "str"}
+    assert mr.load(ContainerDictStr, dumped) == instance
+
+    instance = ContainerDictStr(value={"key": "value"})
+    dumped = mr.dump(ContainerDictStr, instance)
+    assert dumped == {"value": {"key": "value"}}
+    assert mr.load(ContainerDictStr, dumped) == instance
+
+
+def test_union_str_dict() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerStrDict:
+        value: str | dict
+
+    instance = ContainerStrDict(value="str")
+    dumped = mr.dump(ContainerStrDict, instance)
+    assert dumped == {"value": "str"}
+    assert mr.load(ContainerStrDict, dumped) == instance
+
+    instance = ContainerStrDict(value={"key": "value"})
+    dumped = mr.dump(ContainerStrDict, instance)
+    assert dumped == {"value": {"key": "value"}}
+    assert mr.load(ContainerStrDict, dumped) == instance
+
+
+def test_union_dict_str() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerDictStr:
+        value: dict | str
+
+    instance = ContainerDictStr(value="str")
+    dumped = mr.dump(ContainerDictStr, instance)
+    assert dumped == {"value": "str"}
+    assert mr.load(ContainerDictStr, dumped) == instance
+
+    instance = ContainerDictStr(value={"key": "value"})
+    dumped = mr.dump(ContainerDictStr, instance)
+    assert dumped == {"value": {"key": "value"}}
+    assert mr.load(ContainerDictStr, dumped) == instance
+
+
+def test_union_str_generic() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class GenericContainer(Generic[T]):
+        value: T
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerStrGeneric:
+        value: str | GenericContainer[str]
+
+    instance = ContainerStrGeneric(value="str")
+    dumped = mr.dump(ContainerStrGeneric, instance)
+    assert dumped == {"value": "str"}
+    assert mr.load(ContainerStrGeneric, dumped) == instance
+
+    instance = ContainerStrGeneric(value=GenericContainer(value="str"))
+    dumped = mr.dump(ContainerStrGeneric, instance)
+    assert dumped == {"value": {"value": "str"}}
+    assert mr.load(ContainerStrGeneric, dumped) == instance
+
+
+def test_union_generic_str() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class GenericContainer(Generic[T]):
+        value: T
+
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerGenericStr:
+        value: GenericContainer[str] | str
+
+    instance = ContainerGenericStr(value="str")
+    dumped = mr.dump(ContainerGenericStr, instance)
+    assert dumped == {"value": "str"}
+    assert mr.load(ContainerGenericStr, dumped) == instance
+
+    instance = ContainerGenericStr(value=GenericContainer(value="str"))
+    dumped = mr.dump(ContainerGenericStr, instance)
+    assert dumped == {"value": {"value": "str"}}
+    assert mr.load(ContainerGenericStr, dumped) == instance

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -911,6 +911,10 @@ def test_union_priority_str_int() -> None:
     assert dumped == {"value": "123"}
     assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value=123)
 
+    instance = ContainerStrInt(value="abc")
+    dumped = mr.dump(ContainerStrInt, instance)
+    assert dumped == {"value": "abc"}
+    assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value="abc")
 
 def test_union_str_parametrised_dict() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -80,6 +80,8 @@ def test_simple_types() -> None:
         optional_enum_str_field: Parity | None
         enum_int_field: Bit
         optional_enum_int_field: Bit | None
+        str_int_union: int | str
+        optional_str_int_union: int | str | None
         # with default
         str_field_with_default: str = "42"
         bool_field_with_default: bool = True
@@ -94,6 +96,7 @@ def test_simple_types() -> None:
         date_field_with_default: datetime.date = datetime.date(2022, 2, 20)
         enum_str_field_with_default: Parity = Parity.ODD
         enum_int_field_with_default: Bit = Bit.Zero
+        str_int_union_with_default: int | str = 42
         # with default factory
         str_field_with_default_factory: str = dataclasses.field(default_factory=lambda: "42")
         bool_field_with_default_factory: bool = dataclasses.field(default_factory=lambda: True)
@@ -122,6 +125,7 @@ def test_simple_types() -> None:
         tuple_field_with_default_factory: tuple[str, ...] = dataclasses.field(default_factory=lambda: tuple())
         enum_str_field_with_default_factory: Parity = dataclasses.field(default_factory=lambda: Parity.ODD)
         enum_int_field_with_default_factory: Bit = dataclasses.field(default_factory=lambda: Bit.Zero)
+        str_int_union_with_default_factory: int | str = dataclasses.field(default_factory=lambda: 42)
 
     raw = dict(
         any_field={},
@@ -175,6 +179,10 @@ def test_simple_types() -> None:
         optional_list_field=["value"],
         set_field=["value"],
         set_field_with_default_factory=[],
+        str_int_union=42,
+        optional_str_int_union=42,
+        str_int_union_with_default=42,
+        str_int_union_with_default_factory=42,
         optional_set_field=["value"],
         tuple_field=["value"],
         tuple_field_with_default_factory=[],
@@ -240,6 +248,10 @@ def test_simple_types() -> None:
             optional_enum_str_field=Parity.EVEN,
             enum_int_field=Bit.Zero,
             optional_enum_int_field=Bit.One,
+            str_int_union=42,
+            optional_str_int_union=42,
+            str_int_union_with_default=42,
+            str_int_union_with_default_factory=42,
         )
     )
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1019,3 +1019,19 @@ def test_union_generic_str() -> None:
     assert isinstance(instance.value, GenericContainer)
     assert dumped == {"value": {"value": "str"}}
     assert mr.load(ContainerGenericStr, dumped) == instance
+
+
+def test_union_int_float() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerIntFloat:
+        value: int | float
+
+    instance = ContainerIntFloat(value=13)
+    dumped = mr.dump(ContainerIntFloat, instance)
+    assert dumped == {"value": 13}
+    assert mr.load(ContainerIntFloat, dumped) == instance
+
+    instance = ContainerIntFloat(value=13.7)
+    dumped = mr.dump(ContainerIntFloat, instance)
+    assert dumped == {"value": 13.7}
+    assert mr.load(ContainerIntFloat, dumped) == instance

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1035,3 +1035,19 @@ def test_union_int_float() -> None:
     dumped = mr.dump(ContainerIntFloat, instance)
     assert dumped == {"value": 13.7}
     assert mr.load(ContainerIntFloat, dumped) == instance
+
+
+def test_union_float_int() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerIntFloat:
+        value: float | int
+
+    instance = ContainerIntFloat(value=13)
+    dumped = mr.dump(ContainerIntFloat, instance)
+    assert dumped == {"value": 13}
+    assert mr.load(ContainerIntFloat, dumped) == instance
+
+    instance = ContainerIntFloat(value=13.7)
+    dumped = mr.dump(ContainerIntFloat, instance)
+    assert dumped == {"value": 13.7}
+    assert mr.load(ContainerIntFloat, dumped) == instance

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -875,3 +875,53 @@ def test_unsubscripted_collections() -> None:
         "m": {3: 4, "mm": "va"},
         "t": [99, "xx"],
     }
+
+
+def test_union_priority_int_str() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerIntStr:
+        value: int | str
+
+    instance = ContainerIntStr(value=123)
+    dumped = mr.dump(ContainerIntStr, instance)
+
+    assert dumped == {"value": 123}
+    assert mr.load(ContainerIntStr, dumped) == instance
+
+    instance = ContainerIntStr(value="123")
+    dumped = mr.dump(ContainerIntStr, instance)
+
+    assert dumped == {"value": "123"}
+    assert mr.load(ContainerIntStr, dumped) == instance
+
+
+def test_union_priority_str_int() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerStrInt:
+        value: str | int
+
+    instance = ContainerStrInt(value=123)
+    dumped = mr.dump(ContainerStrInt, instance)
+    assert dumped == {"value": 123}
+    assert mr.load(ContainerStrInt, dumped) == instance
+
+    instance = ContainerStrInt(value="123")
+    dumped = mr.dump(ContainerStrInt, instance)
+    assert dumped == {"value": "123"}
+    assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value=123)
+
+
+def test_union_str_or_dict() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class ContainerStrDict:
+        value: str | dict[str, Any]
+
+    instance = ContainerStrDict(value="str")
+    dumped = mr.dump(ContainerStrDict, instance)
+    assert dumped == {"value": "str"}
+    assert mr.load(ContainerStrDict, dumped) == instance
+
+    instance = ContainerStrDict(value={"key": "value"})
+    dumped = mr.dump(ContainerStrDict, instance)
+    assert dumped == {"value": {"key": "value"}}
+    assert mr.load(ContainerStrDict, dumped) == instance

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -887,13 +887,18 @@ def test_union_priority_int_str() -> None:
     dumped = mr.dump(ContainerIntStr, instance)
 
     assert dumped == {"value": 123}
-    assert mr.load(ContainerIntStr, dumped) == instance
+    assert mr.load(ContainerIntStr, dumped) == ContainerIntStr(value=123)
 
     instance = ContainerIntStr(value="123")
     dumped = mr.dump(ContainerIntStr, instance)
 
     assert dumped == {"value": "123"}
-    assert mr.load(ContainerIntStr, dumped) == instance
+    assert mr.load(ContainerIntStr, dumped) == ContainerIntStr(value=123)
+
+    instance = ContainerIntStr(value="abc")
+    dumped = mr.dump(ContainerIntStr, instance)
+    assert dumped == {"value": "abc"}
+    assert mr.load(ContainerIntStr, dumped) == ContainerIntStr(value="abc")
 
 
 def test_union_priority_str_int() -> None:
@@ -904,17 +909,12 @@ def test_union_priority_str_int() -> None:
     instance = ContainerStrInt(value=123)
     dumped = mr.dump(ContainerStrInt, instance)
     assert dumped == {"value": 123}
-    assert mr.load(ContainerStrInt, dumped) == instance
+    assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value=123)
 
     instance = ContainerStrInt(value="123")
     dumped = mr.dump(ContainerStrInt, instance)
     assert dumped == {"value": "123"}
-    assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value=123)
-
-    instance = ContainerStrInt(value="abc")
-    dumped = mr.dump(ContainerStrInt, instance)
-    assert dumped == {"value": "abc"}
-    assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value="abc")
+    assert mr.load(ContainerStrInt, dumped) == ContainerStrInt(value="123")
 
 
 def test_union_str_parametrised_dict() -> None:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1014,8 +1014,8 @@ def test_union_generic_str() -> None:
     dumped = mr.dump(ContainerGenericStr, instance)
     assert dumped == {"value": "str"}
     assert mr.load(ContainerGenericStr, dumped) == instance
-
     instance = ContainerGenericStr(value=GenericContainer(value="str"))
     dumped = mr.dump(ContainerGenericStr, instance)
+    assert isinstance(instance.value, GenericContainer)
     assert dumped == {"value": {"value": "str"}}
     assert mr.load(ContainerGenericStr, dumped) == instance

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@ import dataclasses
 import datetime
 import decimal
 import uuid
-from typing import Annotated, cast
+from typing import Annotated
 
 import marshmallow as m
 import pytest
@@ -152,70 +152,6 @@ def test_tuple_item_validation() -> None:
     assert mr.load(Holder, dict(items=["1"])) == Holder(items=("1",))
 
 
-def test_dump_invalid_value() -> None:
-    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-    class UUIDContainer:
-        uuid_field: uuid.UUID
-
-    with pytest.raises(m.ValidationError) as exc_info:
-        mr.dump(UUIDContainer(uuid_field=cast(uuid.UUID, "invalid")))
-
-    assert exc_info.value.messages == {"uuid_field": ["Invalid value."]}
-
-    with pytest.raises(m.ValidationError) as exc_info:
-        mr.dump(UUIDContainer(uuid_field=cast(uuid.UUID, None)))
-
-    assert exc_info.value.messages == {"uuid_field": ["Missing data for required field."]}
-
-
-def test_dump_many_invalid_value() -> None:
-    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-    class UUIDContainer:
-        uuid_field: uuid.UUID
-
-    with pytest.raises(m.ValidationError) as exc_info:
-        mr.dump_many([UUIDContainer(uuid_field=cast(uuid.UUID, "invalid"))])
-
-    assert exc_info.value.messages == {0: {"uuid_field": ["Invalid value."]}}
-
-    with pytest.raises(m.ValidationError) as exc_info:
-        mr.dump_many([UUIDContainer(uuid_field=cast(uuid.UUID, None))])
-
-    assert exc_info.value.messages == {0: {"uuid_field": ["Missing data for required field."]}}
-
-
-def test_dump_invalid_value_with_custom_name() -> None:
-    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-    class UUIDContainer:
-        uuid_field: uuid.UUID = dataclasses.field(metadata=mr.meta(name="UuidField"))
-
-    with pytest.raises(m.ValidationError) as exc_info:
-        mr.dump(UUIDContainer(uuid_field=cast(uuid.UUID, "invalid")))
-
-    assert exc_info.value.messages == {"UuidField": ["Invalid value."]}
-
-    with pytest.raises(m.ValidationError) as exc_info:
-        mr.dump(UUIDContainer(uuid_field=cast(uuid.UUID, None)))
-
-    assert exc_info.value.messages == {"UuidField": ["Missing data for required field."]}
-
-
-def test_dump_many_invalid_value_with_custom_name() -> None:
-    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-    class UUIDContainer:
-        uuid_field: uuid.UUID = dataclasses.field(metadata=mr.meta(name="UuidField"))
-
-    with pytest.raises(m.ValidationError) as exc_info:
-        mr.dump_many([UUIDContainer(uuid_field=cast(uuid.UUID, "invalid"))])
-
-    assert exc_info.value.messages == {0: {"UuidField": ["Invalid value."]}}
-
-    with pytest.raises(m.ValidationError) as exc_info:
-        mr.dump_many([UUIDContainer(uuid_field=cast(uuid.UUID, None))])
-
-    assert exc_info.value.messages == {0: {"UuidField": ["Missing data for required field."]}}
-
-
 def test_dict_with_complex_value_load_fail() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class Container:
@@ -235,16 +171,6 @@ def test_dict_with_complex_value_load_fail() -> None:
         mr.load(Container, {"values": {"invalid": "invalid", "2020-01-01": 42}})
 
     assert e.value.messages == {"values": {"invalid": {"key": ["Not a valid date."], "value": ["Not a valid number."]}}}
-
-
-@pytest.mark.skip("Bug in marshmallow")
-def test_dump_invalid_int_value() -> None:
-    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
-    class IntContainer:
-        int_field: int
-
-    with pytest.raises(m.ValidationError):
-        mr.dump(IntContainer(int_field=cast(int, "invalid")))
 
 
 def test_regexp_validate() -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -160,7 +160,7 @@ def test_dump_invalid_value() -> None:
     with pytest.raises(m.ValidationError) as exc_info:
         mr.dump(UUIDContainer(uuid_field=cast(uuid.UUID, "invalid")))
 
-    assert exc_info.value.messages == {"uuid_field": ["Not a valid UUID."]}
+    assert exc_info.value.messages == {"uuid_field": ["Invalid value."]}
 
     with pytest.raises(m.ValidationError) as exc_info:
         mr.dump(UUIDContainer(uuid_field=cast(uuid.UUID, None)))
@@ -176,7 +176,7 @@ def test_dump_many_invalid_value() -> None:
     with pytest.raises(m.ValidationError) as exc_info:
         mr.dump_many([UUIDContainer(uuid_field=cast(uuid.UUID, "invalid"))])
 
-    assert exc_info.value.messages == {0: {"uuid_field": ["Not a valid UUID."]}}
+    assert exc_info.value.messages == {0: {"uuid_field": ["Invalid value."]}}
 
     with pytest.raises(m.ValidationError) as exc_info:
         mr.dump_many([UUIDContainer(uuid_field=cast(uuid.UUID, None))])
@@ -192,7 +192,7 @@ def test_dump_invalid_value_with_custom_name() -> None:
     with pytest.raises(m.ValidationError) as exc_info:
         mr.dump(UUIDContainer(uuid_field=cast(uuid.UUID, "invalid")))
 
-    assert exc_info.value.messages == {"UuidField": ["Not a valid UUID."]}
+    assert exc_info.value.messages == {"UuidField": ["Invalid value."]}
 
     with pytest.raises(m.ValidationError) as exc_info:
         mr.dump(UUIDContainer(uuid_field=cast(uuid.UUID, None)))
@@ -208,7 +208,7 @@ def test_dump_many_invalid_value_with_custom_name() -> None:
     with pytest.raises(m.ValidationError) as exc_info:
         mr.dump_many([UUIDContainer(uuid_field=cast(uuid.UUID, "invalid"))])
 
-    assert exc_info.value.messages == {0: {"UuidField": ["Not a valid UUID."]}}
+    assert exc_info.value.messages == {0: {"UuidField": ["Invalid value."]}}
 
     with pytest.raises(m.ValidationError) as exc_info:
         mr.dump_many([UUIDContainer(uuid_field=cast(uuid.UUID, None))])


### PR DESCRIPTION
As part of this, we had to ensure that value passed to a field matches the type we expect: otherwise StrField can serialise any type, IntField can serialise floats and so on... I have decided to do that not only in the context of Union field, but globally, because it makes sense for me.

Also, `with_type_checks_on_serialize` is the fastest way to add type checking for all supported fields.

Also, while deserialising/loading... the order of fields matter:

```
@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
class Container1:
    value: str | int

@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
class Container2:
    value: int | str
```

If value is "123", marshmallow IntField can load it to 123, so in this case `mr.load(Container2, {"value": "123"})` will return `Container2(value=123)`, however `mr.load(Container1, {"value": "123"})` will return `Container1(value="123")`, because types are used from left to right.
