### PR TITLE
If datetime is passed as a date, use only date part of it

### DIFF
--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -3,7 +3,17 @@ import re
 import sys
 
 from .bake import bake_schema, get_field_for
-from .fields import DateTimeField, DictField, EnumField, FrozenSetField, SetField, StrField, TupleField, UnionField
+from .fields import (
+    DateField,
+    DateTimeField,
+    DictField,
+    EnumField,
+    FrozenSetField,
+    SetField,
+    StrField,
+    TupleField,
+    UnionField,
+)
 from .hooks import add_pre_load, pre_load
 from .metadata import (
     EMPTY_METADATA,
@@ -56,6 +66,7 @@ __all__: tuple[str, ...] = (
     "add_pre_load",
     "pre_load",
     # fields.py
+    "DateField",
     "DateTimeField",
     "DictField",
     "FrozenSetField",

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -301,7 +301,7 @@ def date_field(
     **_: Any,
 ) -> m.fields.Field:
     if default is m.missing:
-        return m.fields.Date(
+        return DateField(
             allow_none=allow_none,
             validate=validate,
             **default_fields(m.missing),
@@ -311,9 +311,9 @@ def date_field(
     if required:
         if default is None:
             raise ValueError("Default value cannot be none")
-        return m.fields.Date(required=True, allow_none=allow_none, validate=validate, **data_key_fields(name))
+        return DateField(required=True, allow_none=allow_none, validate=validate, **data_key_fields(name))
 
-    return m.fields.Date(
+    return DateField(
         allow_none=allow_none,
         validate=validate,
         **(default_fields(None) if default is dataclasses.MISSING else {}),
@@ -625,6 +625,7 @@ def union_field(
 
 
 DateTimeField: type[m.fields.DateTime]
+DateField: type[m.fields.Date]
 EnumField: type[m.fields.Field]
 DictField: type[m.fields.Field]
 SetField: type[m.fields.List]
@@ -746,6 +747,14 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
             return super()._serialize(value, attr, obj, **kwargs)
 
     DateTimeField = DateTimeFieldV3
+
+    class DateFieldV3(m.fields.Date):
+        def _serialize(self, value: Any, attr: Any, obj: Any, **kwargs: Any) -> Any:
+            if isinstance(value, datetime.datetime):
+                value = value.date()
+            return super()._serialize(value, attr, obj, **kwargs)
+
+    DateField = DateFieldV3
 
     class SetFieldV3(m.fields.List):
         def _deserialize(self, value: Any, attr: Any, data: Any, **kwargs: Any) -> Any:
@@ -1029,6 +1038,14 @@ else:
             return result.astimezone(datetime.timezone.utc)
 
     DateTimeField = DateTimeFieldV2
+
+    class DateFieldV2(m.fields.Date):
+        def _serialize(self, value: Any, attr: Any, obj: Any, **kwargs: Any) -> Any:
+            if isinstance(value, datetime.datetime):
+                value = value.date()
+            return super()._serialize(value, attr, obj, **kwargs)
+
+    DateField = DateFieldV2
 
     class SetFieldV2(m.fields.List):
         def _deserialize(self, value: Any, attr: Any, data: Any, **_: Any) -> Any:

--- a/tests/test_get_field_for.py
+++ b/tests/test_get_field_for.py
@@ -271,31 +271,31 @@ EMPTY_SCHEMA = m.Schema()
             m.fields.Time(allow_none=True, **default_fields(None), **data_key_fields("i")),
         ),
         # simple types: date
-        (datetime.date, {}, m.fields.Date(required=True)),
+        (datetime.date, {}, mr.DateField(required=True)),
         (
             Optional[datetime.date],
             {},
-            m.fields.Date(allow_none=True, **default_fields(None)),
+            mr.DateField(allow_none=True, **default_fields(None)),
         ),
         (
             datetime.date | None,
             {},
-            m.fields.Date(allow_none=True, **default_fields(None)),
+            mr.DateField(allow_none=True, **default_fields(None)),
         ),
         (
             datetime.date,
             mr.meta(name="i"),
-            m.fields.Date(required=True, **data_key_fields("i")),
+            mr.DateField(required=True, **data_key_fields("i")),
         ),
         (
             Optional[datetime.date],
             mr.meta(name="i"),
-            m.fields.Date(allow_none=True, **default_fields(None), **data_key_fields("i")),
+            mr.DateField(allow_none=True, **default_fields(None), **data_key_fields("i")),
         ),
         (
             datetime.date | None,
             mr.meta(name="i"),
-            m.fields.Date(allow_none=True, **default_fields(None), **data_key_fields("i")),
+            mr.DateField(allow_none=True, **default_fields(None), **data_key_fields("i")),
         ),
         # enum
         (Enum, {}, mr.EnumField(enum_type=Enum, required=True)),
@@ -809,13 +809,13 @@ EMPTY_SCHEMA = m.Schema()
         (
             dict[datetime.date, int],
             {},
-            mr.DictField(keys=m.fields.Date(required=True), values=m.fields.Int(required=True), required=True),
+            mr.DictField(keys=mr.DateField(required=True), values=m.fields.Int(required=True), required=True),
         ),
         (
             dict[datetime.date, int],
             mr.meta(name="i"),
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 required=True,
                 **data_key_fields("i"),
@@ -825,7 +825,7 @@ EMPTY_SCHEMA = m.Schema()
             Optional[dict[datetime.date, int]],
             {},
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 allow_none=True,
                 **default_fields(None),
@@ -835,7 +835,7 @@ EMPTY_SCHEMA = m.Schema()
             Optional[dict[datetime.date, int]],
             mr.meta(name="i"),
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 allow_none=True,
                 **default_fields(None),
@@ -846,7 +846,7 @@ EMPTY_SCHEMA = m.Schema()
             dict[datetime.date, int] | None,
             {},
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 allow_none=True,
                 **default_fields(None),
@@ -856,7 +856,7 @@ EMPTY_SCHEMA = m.Schema()
             dict[datetime.date, int] | None,
             mr.meta(name="i"),
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 allow_none=True,
                 **default_fields(None),
@@ -902,13 +902,13 @@ EMPTY_SCHEMA = m.Schema()
         (
             collections.abc.Mapping[datetime.date, int],
             {},
-            mr.DictField(keys=m.fields.Date(required=True), values=m.fields.Int(required=True), required=True),
+            mr.DictField(keys=mr.DateField(required=True), values=m.fields.Int(required=True), required=True),
         ),
         (
             collections.abc.Mapping[datetime.date, int],
             mr.meta(name="i"),
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 required=True,
                 **data_key_fields("i"),
@@ -918,7 +918,7 @@ EMPTY_SCHEMA = m.Schema()
             Optional[collections.abc.Mapping[datetime.date, int]],
             {},
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 allow_none=True,
                 **default_fields(None),
@@ -928,7 +928,7 @@ EMPTY_SCHEMA = m.Schema()
             Optional[collections.abc.Mapping[datetime.date, int]],
             mr.meta(name="i"),
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 allow_none=True,
                 **default_fields(None),
@@ -939,7 +939,7 @@ EMPTY_SCHEMA = m.Schema()
             collections.abc.Mapping[datetime.date, int] | None,
             {},
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 allow_none=True,
                 **default_fields(None),
@@ -949,7 +949,7 @@ EMPTY_SCHEMA = m.Schema()
             collections.abc.Mapping[datetime.date, int] | None,
             mr.meta(name="i"),
             mr.DictField(
-                keys=m.fields.Date(required=True),
+                keys=mr.DateField(required=True),
                 values=m.fields.Int(required=True),
                 allow_none=True,
                 **default_fields(None),

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1062,3 +1062,14 @@ def test_integral_float() -> None:
     dumped = mr.dump(Container, instance)
     assert dumped == {"value": 1}
     assert mr.load(Container, dumped) == instance
+
+
+def test_datetime_as_date() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class DateTimeContainer:
+        date_field: datetime.date
+
+    now = datetime.datetime.now(datetime.UTC)
+    dumped = mr.dump(DateTimeContainer(date_field=now))
+
+    assert dumped == {"date_field": now.date().isoformat()}


### PR DESCRIPTION
The problem here is the following:

<img width="598" height="175" alt="image" src="https://github.com/user-attachments/assets/8ae62820-4d7b-4e98-9c73-eb362cd45ca6" />


So, if a datetime is passed as a date it used to serialize as a datetime, but it should be serialised as date.