### PR TITLE
Cyclic references support

### DIFF
--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -322,7 +322,7 @@ def date_field(
 
 
 def nested_field(
-    nested_schema: type[m.Schema],
+    nested_schema: type[m.Schema] | collections.abc.Callable[[], type[m.Schema]],
     *,
     required: bool,
     allow_none: bool,

--- a/marshmallow_recipe/generics.py
+++ b/marshmallow_recipe/generics.py
@@ -38,8 +38,9 @@ def get_fields_type_map(cls: type) -> FieldsTypeMap:
 
     class_type_var_map = get_class_type_var_map(cls)
     fields_class_map = get_fields_class_map(origin)
+    field_type_hints = typing.get_type_hints(origin, include_extras=True)
     return {
-        f.name: build_subscripted_type(f.type, class_type_var_map.get(fields_class_map[f.name], {}))
+        f.name: build_subscripted_type(field_type_hints[f.name], class_type_var_map.get(fields_class_map[f.name], {}))
         for f in dataclasses.fields(origin)
     }
 

--- a/marshmallow_recipe/serialization.py
+++ b/marshmallow_recipe/serialization.py
@@ -4,9 +4,9 @@ from typing import Any, TypeVar, overload
 
 import marshmallow as m
 
-from .missing import MISSING
 from .bake import bake_schema
 from .generics import extract_type
+from .missing import MISSING
 from .naming_case import NamingCase
 
 _T = TypeVar("_T")


### PR DESCRIPTION
Added cyclic nested schema references support via lambda `Nested` fields. Had to introduce private versions of main `bake` module functions in order to carry backtracking set around