### PR TITLE
Allow whole number floats in integer fields

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -52,6 +52,7 @@ def test_simple_types() -> None:
         decimal_field: decimal.Decimal
         optional_decimal_field: decimal.Decimal | None
         int_field: int
+        int_field_as_float: int
         optional_int_field: int | None
         new_int_field: NewInt
         optional_new_int_field: NewInt | None
@@ -144,6 +145,7 @@ def test_simple_types() -> None:
         decimal_field_with_default_factory="42.00",
         optional_decimal_field="42.00",
         int_field=42,
+        int_field_as_float=42.0,
         int_field_with_default=42,
         int_field_with_default_factory=42,
         optional_int_field=42,
@@ -220,6 +222,7 @@ def test_simple_types() -> None:
             decimal_field=decimal.Decimal("42.00"),
             optional_decimal_field=decimal.Decimal("42.00"),
             int_field=42,
+            int_field_as_float=42,
             optional_int_field=42,
             new_int_field=NewInt(42),
             optional_new_int_field=NewInt(42),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,6 +20,11 @@ def test_int_validation() -> None:
 
     mr.load(Holder, dict(value=42))
 
+    with pytest.raises(m.ValidationError):
+        mr.load(Holder, dict(value=36.6))
+
+    mr.load(Holder, dict(value=36.0))
+
 
 def test_float_validation() -> None:
     @dataclasses.dataclass


### PR DESCRIPTION
### Summary
This pull request enhances the integer field deserialization functionality to accept float values that represent whole numbers (e.g., 42.0). This improves flexibility when handling data sources that may expose integers as float values.

### Changes Introduced
- Replaced tuple type guards with callable validators in `int_field()` function.
- Added an `is_integer()` check for float values during integer validation.
- Updated Marshmallow v2 and v3 compatibility layers to integrate the improvement.
- Included comprehensive test cases to ensure correct behavior for float-as-int scenarios.
