### PR TITLE
Fix UUID invalid_error not being applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.0.69 (unreleased)
 
 * [Add JsonRawField with JSON validation for Any type fields](https://github.com/anna-money/marshmallow-recipe/pull/212)
+* [Fix UUID invalid_error not being applied](https://github.com/anna-money/marshmallow-recipe/pull/213)
 
 
 ## v0.0.68 (2025-12-16)

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -312,7 +312,7 @@ def uuid_field(
             **default_fields(m.missing),
             **data_key_fields(name),
             **description_fields(description),
-            error_messages=build_error_messages(
+            error_messages=build_uuid_error_messages(
                 required_error=required_error, none_error=none_error, invalid_error=invalid_error
             ),
         )
@@ -326,7 +326,7 @@ def uuid_field(
             validate=validate,
             **data_key_fields(name),
             **description_fields(description),
-            error_messages=build_error_messages(
+            error_messages=build_uuid_error_messages(
                 required_error=required_error, none_error=none_error, invalid_error=invalid_error
             ),
         )
@@ -337,7 +337,7 @@ def uuid_field(
         **(default_fields(None) if default is dataclasses.MISSING else {}),
         **data_key_fields(name),
         **description_fields(description),
-        error_messages=build_error_messages(
+        error_messages=build_uuid_error_messages(
             required_error=required_error, none_error=none_error, invalid_error=invalid_error
         ),
     )
@@ -989,6 +989,20 @@ def build_error_messages(
         error_messages["null"] = none_error
     if invalid_error is not None:
         error_messages["invalid"] = invalid_error
+
+    return error_messages if error_messages else None
+
+
+def build_uuid_error_messages(
+    *, required_error: str | None = None, none_error: str | None = None, invalid_error: str | None = None
+) -> dict[str, str] | None:
+    error_messages = {}
+    if required_error is not None:
+        error_messages["required"] = required_error
+    if none_error is not None:
+        error_messages["null"] = none_error
+    if invalid_error is not None:
+        error_messages["invalid_uuid"] = invalid_error
 
     return error_messages if error_messages else None
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -404,6 +404,22 @@ def test_error_messages_optional_field() -> None:
     assert mr.load(Config, {}) == Config(value=None)
 
 
+def test_error_messages_uuid_field() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class Entity:
+        id: Annotated[uuid.UUID, mr.meta(required_error="ID is required", invalid_error="Invalid UUID format")]
+
+    # Test custom required error message
+    with pytest.raises(m.ValidationError) as exc_info:
+        mr.load(Entity, {})
+    assert exc_info.value.messages == {"id": ["ID is required"]}
+
+    # Test custom invalid error message
+    with pytest.raises(m.ValidationError) as exc_info:
+        mr.load(Entity, {"id": "not-a-uuid"})
+    assert exc_info.value.messages == {"id": ["Invalid UUID format"]}
+
+
 def test_error_messages_multiple_fields() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class User:


### PR DESCRIPTION
## Summary
- Marshmallow's UUID field uses `invalid_uuid` error key instead of `invalid`
- Add `build_uuid_error_messages` function that maps `invalid_error` to the correct key
- Add test for UUID custom error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)