### PR TITLE
Switch to VCS-based versioning with hatch-vcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [Add JsonRawField with JSON validation for Any type fields](https://github.com/anna-money/marshmallow-recipe/pull/212)
 * [Fix UUID invalid_error not being applied](https://github.com/anna-money/marshmallow-recipe/pull/213)
 * [Fix int values being converted to float when dumping float fields](https://github.com/anna-money/marshmallow-recipe/pull/214)
+* Switch to VCS-based versioning with hatch-vcs
 * [Fix collection field error messages](https://github.com/anna-money/marshmallow-recipe/pull/216)
 
 

--- a/marshmallow_recipe/__init__.py
+++ b/marshmallow_recipe/__init__.py
@@ -1,6 +1,5 @@
-import collections
-import re
 import sys
+from importlib.metadata import version as _get_version
 
 from .bake import bake_schema, get_field_for
 from .fields import (
@@ -125,28 +124,6 @@ __all__: tuple[str, ...] = (
     "validate",
 )
 
-__version__ = "0.0.68"
+__version__ = _get_version("marshmallow-recipe")
 
 version = f"{__version__}, Python {sys.version}"
-
-VersionInfo = collections.namedtuple("VersionInfo", "major minor micro release_level serial")  # type: ignore
-
-
-def _parse_version(v: str) -> VersionInfo:
-    version_re = r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<micro>\d+)" r"((?P<release_level>[a-z]+)(?P<serial>\d+)?)?$"
-    match = re.match(version_re, v)
-    if not match:
-        raise ImportError(f"Invalid package version {v}")
-    try:
-        major = int(match.group("major"))
-        minor = int(match.group("minor"))
-        micro = int(match.group("micro"))
-        levels = {"rc": "candidate", "a": "alpha", "b": "beta", None: "final"}
-        release_level = levels[match.group("release_level")]
-        serial = int(match.group("serial")) if match.group("serial") else 0
-        return VersionInfo(major, minor, micro, release_level, serial)
-    except Exception as e:
-        raise ImportError(f"Invalid package version {v}") from e
-
-
-version_info = _parse_version(__version__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -39,7 +39,7 @@ dev = [
 ]
 
 [tool.hatch.version]
-path = "marshmallow_recipe/__init__.py"
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["marshmallow_recipe"]


### PR DESCRIPTION
## Summary
- Use hatch-vcs to derive version from git tags automatically
- Read version via `importlib.metadata` in `__init__.py`
- Remove hardcoded version and unused `VersionInfo` parsing code

## Test plan
- [x] `uv sync` works
- [x] `python -c "import marshmallow_recipe; print(marshmallow_recipe.__version__)"` shows correct version
- [x] `make lint` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)