### PR TITLE
Fix obj_type parameter in type check error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [Fix collection field error messages](https://github.com/anna-money/marshmallow-recipe/pull/216)
 * [Strict enum type checking and reject bool for int/float fields on dump](https://github.com/anna-money/marshmallow-recipe/pull/219)
 * [Add `frozenset_meta`/`frozenset_metadata` for consistency with other collection types](https://github.com/anna-money/marshmallow-recipe/pull/220)
+* [Fix obj_type parameter in type check error messages for DateTime/Time fields](https://github.com/anna-money/marshmallow-recipe/pull/221)
 
 
 ## v0.0.68 (2025-12-16)

--- a/marshmallow_recipe/fields.py
+++ b/marshmallow_recipe/fields.py
@@ -1013,6 +1013,8 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
         field: TField, type_guards: type | tuple[type, ...], type_guards_to_exclude: type | tuple[type, ...] = ()
     ) -> TField:
         fail_key = "invalid" if "invalid" in field.default_error_messages else "validator_failed"
+        invalid_msg = str(field.default_error_messages.get("invalid", ""))
+        obj_type = getattr(field, "OBJ_TYPE", None) if "{obj_type}" in invalid_msg else None
 
         old = field._serialize  # type: ignore
 
@@ -1020,6 +1022,8 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
             if value is not None and not (
                 isinstance(value, type_guards) and not isinstance(value, type_guards_to_exclude)
             ):
+                if obj_type is not None:
+                    raise self.make_error(fail_key, obj_type=obj_type)  # type: ignore
                 raise self.make_error(fail_key)  # type: ignore
             return old(value, attr, obj, **kwargs)
 


### PR DESCRIPTION
## Summary
- Fix `obj_type` parameter handling in `with_type_checks_on_serialize_v3` function
- DateTime and Time fields use `{obj_type}` placeholder in their error messages - this fix ensures the placeholder is properly substituted

Backported from v2 branch: https://github.com/anna-money/marshmallow-recipe/commit/c2b8986

## Test plan
- [x] `make lint` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)