### PR TITLE
Fix segfault in direct slot access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [Add `int_meta`/`float_meta` with range validation (`gt`, `gte`, `lt`, `lte`) support](https://github.com/anna-money/marshmallow-recipe/pull/277)
 * [Add string `"0"`/`"1"` support to nuked bool deserialization](https://github.com/anna-money/marshmallow-recipe/pull/280)
 * [Fix `None` handling in multi-type unions (e.g. `dict | str | None`) in nuked](https://github.com/anna-money/marshmallow-recipe/pull/279)
+* [Fix segfault when dumping MagicMock objects via direct slot access](https://github.com/anna-money/marshmallow-recipe/pull/278)
 
 
 ## v0.0.86 (2026-03-06)

--- a/src/container_dump.rs
+++ b/src/container_dump.rs
@@ -148,6 +148,11 @@ impl DataclassContainer {
             ));
         }
 
+        let use_direct_slots = value
+            .get_type()
+            .is_subclass(self.cls.bind(py))
+            .unwrap_or(false);
+
         let missing_sentinel = crate::utils::get_missing_sentinel(py)
             .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
 
@@ -158,7 +163,7 @@ impl DataclassContainer {
             let common = dc_field.field.common();
 
             let py_value = match dc_field.slot_offset {
-                Some(offset) => {
+                Some(offset) if use_direct_slots => {
                     match unsafe { crate::slots::get_slot_value_direct(py, value, offset) } {
                         Some(v) => v,
                         None => value
@@ -166,7 +171,7 @@ impl DataclassContainer {
                             .map_err(|e| SerializationError::simple(py, &e.to_string()))?,
                     }
                 }
-                None => value
+                _ => value
                     .getattr(dc_field.name_interned.bind(py))
                     .map_err(|e| SerializationError::simple(py, &e.to_string()))?,
             };

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -3,10 +3,16 @@ use pyo3::prelude::*;
 // These functions provide direct memory access to Python object slots,
 // bypassing the normal attribute access mechanism for better performance.
 //
-// SAFETY: The offset must be properly aligned for pointer access.
-// This is guaranteed by filtering out unaligned offsets when extracting
-// slot_offset in cache.rs and types.rs. We use debug_assert! to catch
-// any misuse during development.
+// SAFETY:
+// 1. The offset must be properly aligned for pointer access.
+//    This is guaranteed by filtering out unaligned offsets when extracting
+//    slot_offset in cache.rs and types.rs. We use debug_assert! to catch
+//    any misuse during development.
+// 2. The offset must be within the object's tp_basicsize.
+//    This is validated at runtime to prevent out-of-bounds reads on objects
+//    whose memory layout differs from the expected dataclass (e.g. mocks).
+//    If the offset is out of bounds, these functions return None/false,
+//    causing callers to fall back to safe getattr/setattr.
 //
 // The cast_ptr_alignment warning is suppressed because:
 // 1. Python objects are allocated via malloc, which returns aligned pointers
@@ -30,6 +36,13 @@ pub unsafe fn get_slot_value_direct<'py>(
     if obj_ptr.is_null() {
         return None;
     }
+
+    let basicsize = unsafe { (*(*obj_ptr).ob_type).tp_basicsize }.cast_unsigned();
+    let end = offset.cast_unsigned() + std::mem::size_of::<*mut pyo3::ffi::PyObject>();
+    if end > basicsize {
+        return None;
+    }
+
     unsafe {
         let slot_ptr = (obj_ptr as *const u8)
             .offset(offset)
@@ -56,6 +69,13 @@ pub unsafe fn set_slot_value_direct(
     if obj_ptr.is_null() {
         return false;
     }
+
+    let basicsize = unsafe { (*(*obj_ptr).ob_type).tp_basicsize }.cast_unsigned();
+    let end = offset.cast_unsigned() + std::mem::size_of::<*mut pyo3::ffi::PyObject>();
+    if end > basicsize {
+        return false;
+    }
+
     unsafe {
         let slot_ptr = obj_ptr
             .cast::<u8>()

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -282,6 +282,11 @@ def impl(request: pytest.FixtureRequest) -> Serializer:
     return request.param
 
 
+@pytest.fixture(params=[NukedSerializer(), NukedSchemaSerializer()], ids=["nuked", "nuked_schema"])
+def nuked_impl(request: pytest.FixtureRequest) -> Serializer:
+    return request.param
+
+
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class ValueOf[T]:
     value: T

--- a/tests/api/test_direct_slots.py
+++ b/tests/api/test_direct_slots.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+from unittest.mock import MagicMock
 
 from .conftest import Serializer
 
@@ -127,6 +128,23 @@ class TestDirectSlotsDump:
         )
         result = json.loads(impl.dump(WithNestedList, obj))
         assert result == {"name": "container", "items": [{"id": 1, "label": "first"}, {"id": 2, "label": "second"}]}
+
+    def test_mock_with_spec(self, nuked_impl: Serializer) -> None:
+        real = BasicSlots(name="test", value=123)
+        mock = MagicMock(spec=BasicSlots)
+        for f in dataclasses.fields(BasicSlots):
+            setattr(mock, f.name, getattr(real, f.name))
+        result = json.loads(nuked_impl.dump(BasicSlots, mock))
+        assert result == {"name": "test", "value": 123}
+
+    def test_mock_with_spec_nested(self, nuked_impl: Serializer) -> None:
+        real_item = NestedItem(id=1, label="first")
+        real = WithNestedList(name="container", items=[real_item])
+        mock = MagicMock(spec=WithNestedList)
+        for f in dataclasses.fields(WithNestedList):
+            setattr(mock, f.name, getattr(real, f.name))
+        result = json.loads(nuked_impl.dump(WithNestedList, mock))
+        assert result == {"name": "container", "items": [{"id": 1, "label": "first"}]}
 
 
 class TestDirectSlotsLoad:


### PR DESCRIPTION
## Summary

- **Fix segfault**: `MagicMock(spec=X)` passes `isinstance()` via `__instancecheck__` but has `tp_basicsize=16` (just PyObject header), while real dataclasses have 32+. Direct slot reads at dataclass offsets caused out-of-bounds memory access → segfault on Python 3.14
- **Defense layer 1** (`container_dump.rs`): Use `issubclass(type(obj), cls)` to skip direct slot access for non-true-subclass objects, falling back to safe `getattr`
- **Defense layer 2** (`slots.rs`): Validate `offset + ptr_size <= tp_basicsize` before any pointer arithmetic — if out of bounds, return `None`/`false` to trigger `getattr` fallback instead of segfaulting

## Technical Details

`MagicMock(spec=Foo)` overrides `__instancecheck__` so `isinstance(mock, Foo)` returns `True`, but `type(mock)` is `MagicMock` with a completely different memory layout. The two independent safety layers ensure that even if one check is bypassed, we never perform unsafe out-of-bounds reads.

## Test Plan

- [x] Added `test_mock_with_spec` — dumps MagicMock with set attributes, verifies correct JSON output
- [x] Added `test_mock_with_spec_nested` — same for dataclass with nested list
- [x] Both tests run via `nuked_impl` fixture (nuked + nuked_schema paths)
- [x] All 5558 tests pass, lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)