### PR TITLE
Use covariant Sequence instead of list in load_many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.97 (2026-05-12)
+
+* [Use covariant `Sequence` instead of `list` in `load_many`](https://github.com/anna-money/marshmallow-recipe/pull/305)
+
+
 ## v0.0.96 (2026-05-09)
 
 * [Bump rust dependencies](https://github.com/anna-money/marshmallow-recipe/pull/304)

--- a/python/marshmallow_recipe/serialization.py
+++ b/python/marshmallow_recipe/serialization.py
@@ -1,6 +1,5 @@
 import importlib.metadata
 import warnings
-from collections.abc import Mapping
 from typing import Any, ClassVar, Protocol, get_args, overload
 
 import marshmallow as m
@@ -66,7 +65,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     def load_v3[T](
         cls: type[T],
-        data: Mapping[str, Any],
+        data: dict[str, Any],
         /,
         *,
         naming_case: NamingCase | None = None,
@@ -112,7 +111,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     def _load_union_v3(
         union_type: Any,
-        data: Mapping[str, Any],
+        data: dict[str, Any],
         *,
         naming_case: NamingCase | None,
         none_value_handling: NoneValueHandling | None,
@@ -137,7 +136,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     def load_many_v3[T](
         cls: type[T],
-        data: list[Mapping[str, Any]],
+        data: list[dict[str, Any]],
         /,
         *,
         naming_case: NamingCase | None = None,
@@ -278,7 +277,7 @@ else:
 
     def load_v2[T](
         cls: type[T],
-        data: Mapping[str, Any],
+        data: dict[str, Any],
         /,
         *,
         naming_case: NamingCase | None = None,
@@ -309,7 +308,7 @@ else:
 
     def _load_union_v2(
         union_type: Any,
-        data: Mapping[str, Any],
+        data: dict[str, Any],
         *,
         naming_case: NamingCase | None,
         none_value_handling: NoneValueHandling | None,
@@ -334,7 +333,7 @@ else:
 
     def load_many_v2[T](
         cls: type[T],
-        data: list[Mapping[str, Any]],
+        data: list[dict[str, Any]],
         /,
         *,
         naming_case: NamingCase | None = None,

--- a/python/marshmallow_recipe/serialization.py
+++ b/python/marshmallow_recipe/serialization.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import warnings
+from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar, Protocol, get_args, overload
 
 import marshmallow as m
@@ -65,7 +66,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     def load_v3[T](
         cls: type[T],
-        data: dict[str, Any],
+        data: Mapping[str, Any],
         /,
         *,
         naming_case: NamingCase | None = None,
@@ -111,7 +112,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     def _load_union_v3(
         union_type: Any,
-        data: dict[str, Any],
+        data: Mapping[str, Any],
         *,
         naming_case: NamingCase | None,
         none_value_handling: NoneValueHandling | None,
@@ -136,7 +137,7 @@ if _MARSHMALLOW_VERSION_MAJOR >= 3:
 
     def load_many_v3[T](
         cls: type[T],
-        data: list[dict[str, Any]],
+        data: Sequence[Mapping[str, Any]],
         /,
         *,
         naming_case: NamingCase | None = None,
@@ -277,7 +278,7 @@ else:
 
     def load_v2[T](
         cls: type[T],
-        data: dict[str, Any],
+        data: Mapping[str, Any],
         /,
         *,
         naming_case: NamingCase | None = None,
@@ -308,7 +309,7 @@ else:
 
     def _load_union_v2(
         union_type: Any,
-        data: dict[str, Any],
+        data: Mapping[str, Any],
         *,
         naming_case: NamingCase | None,
         none_value_handling: NoneValueHandling | None,
@@ -333,7 +334,7 @@ else:
 
     def load_many_v2[T](
         cls: type[T],
-        data: list[dict[str, Any]],
+        data: Sequence[Mapping[str, Any]],
         /,
         *,
         naming_case: NamingCase | None = None,


### PR DESCRIPTION
## Summary
- After #303 widened `load`/`load_many` parameter types from `dict` to `Mapping`, calling `load_many(cls, some_list_of_dicts)` started failing type checking, because `list` is invariant: `list[dict[str, Any]]` is **not** a subtype of `list[Mapping[str, Any]]`.
- Fix by switching `load_many` to `Sequence[Mapping[str, Any]]`. `Sequence` is covariant, so `list[dict[str, Any]]`, `list[Mapping[str, Any]]`, tuples, and other read-only sequences of mappings all type-check.
- `load` is left as `Mapping[str, Any]` — there's no invariance problem there (`dict` is a `Mapping`).

## Test plan
- [ ] `make lint`
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)