### PR TITLE
Render T | None as nullable in mr.json_schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.0.98 (2026-05-29)
 
 * **Breaking:** `mr.json_schema()` now renders `T | None` as nullable JSON Schema. `str | None` becomes `{"type": ["string", "null"]}`; `Nested | None` becomes `{"anyOf": [{"$ref": "#/$defs/Nested"}, {"type": "null"}]}`; nullable enums and `Literal` types include `null` in both the `type` list and the `enum` list. Previously the `None` branch was dropped, producing schemas that rejected `null` even though the Python type allowed it. `NoneValueHandling` does not affect schema rendering — it remains a serialization-only setting.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* **Breaking:** `mr.json_schema()` now renders `T | None` as nullable JSON Schema. `str | None` becomes `{"type": ["string", "null"]}`; `Nested | None` becomes `{"anyOf": [{"$ref": "#/$defs/Nested"}, {"type": "null"}]}`; nullable enums and `Literal` types include `null` in both the `type` list and the `enum` list. Previously the `None` branch was dropped, producing schemas that rejected `null` even though the Python type allowed it. `NoneValueHandling` does not affect schema rendering — it remains a serialization-only setting.
+
+
 ## v0.0.97 (2026-05-12)
 
 * [Use covariant `Sequence` instead of `list` in `load_many`](https://github.com/anna-money/marshmallow-recipe/pull/305)

--- a/context7.json
+++ b/context7.json
@@ -60,7 +60,7 @@
     "JSON Schema: Literal types include allowed values - Literal['a', 'b'] → {\"type\": \"string\", \"enum\": [\"a\", \"b\"]}",
     "JSON Schema: Collections mapped - list→array, set→array with uniqueItems, dict→object with additionalProperties",
     "JSON Schema: Union types (str | int) mapped to anyOf - {\"anyOf\": [{\"type\": \"string\"}, {\"type\": \"integer\"}]}",
-    "JSON Schema: Optional fields (T | None) not in required array, but type is not anyOf with null",
+    "JSON Schema: Optional fields (T | None) render as nullable. str | None → {\"type\": [\"string\", \"null\"]}; Nested | None → {\"anyOf\": [{\"$ref\": \"#/$defs/Nested\"}, {\"type\": \"null\"}]}; T1 | T2 | None → {\"anyOf\": [<T1>, <T2>, {\"type\": \"null\"}]}; Literal/Enum | None adds null to both the type list and the enum list",
     "JSON Schema: Nested dataclasses use $defs and $ref for reusability - {\"$ref\": \"#/$defs/ClassName\"}",
     "JSON Schema: Cyclic/self-referential types handled automatically without infinite recursion",
     "JSON Schema: Field descriptions via Annotated[T, mr.meta(description='...')] → {\"description\": \"...\"}",

--- a/examples/13_json_schema_generation.md
+++ b/examples/13_json_schema_generation.md
@@ -34,11 +34,13 @@ Output:
     "id": {"type": "integer"},
     "name": {"type": "string"},
     "email": {"type": "string"},
-    "age": {"type": "integer"}
+    "age": {"type": ["integer", "null"]}
   },
   "required": ["id", "name", "email"]
 }
 ```
+
+`T | None` always renders as a nullable JSON Schema (here `["integer", "null"]`), regardless of the `none_value_handling` setting. `none_value_handling` only controls serialization (whether `mr.dump` emits `"age": null` or omits the key); JSON Schema describes what input is valid, and `null` is valid whenever the Python type is `T | None`.
 
 ## Field Descriptions
 
@@ -284,11 +286,30 @@ Output:
       ]
     },
     "optional": {
-      "type": "string"
+      "type": ["string", "null"],
+      "default": null
     }
   },
   "required": ["value"]
 }
+```
+
+When a union includes `None` and exactly one other type, the result is a nullable type list. For unions with multiple non-`None` members plus `None` (e.g. `int | str | None`), the `null` branch is appended to `anyOf`:
+
+```json
+{"anyOf": [{"type": "integer"}, {"type": "string"}, {"type": "null"}]}
+```
+
+For nullable nested dataclasses (`Inner | None`), the `$ref` is wrapped in `anyOf` (the 2020-12 spec forbids siblings on a `$ref`-only schema):
+
+```json
+{"anyOf": [{"$ref": "#/$defs/Inner"}, {"type": "null"}]}
+```
+
+For nullable enums or `Literal`, `null` appears both in the `type` list and in `enum` (validators check them independently):
+
+```json
+{"type": ["string", "null"], "enum": ["a", "b", null]}
 ```
 
 ## Nested Dataclasses

--- a/python/marshmallow_recipe/json_schema.py
+++ b/python/marshmallow_recipe/json_schema.py
@@ -120,6 +120,33 @@ def __is_optional(field_type: TypeLike) -> bool:
     return any(t is types.NoneType for t in underlying_union_types)
 
 
+def __add_null_branch(schema: dict[str, Any]) -> None:
+    """Mutate `schema` in place to also accept JSON null.
+
+    For ``$ref`` schemas, rewrites to ``anyOf`` because the 2020-12 spec
+    forbids siblings on a $ref-only schema. For typed schemas, appends
+    ``"null"`` to the ``type`` list and ``None`` to ``enum`` when present —
+    validators check ``type`` and ``enum`` independently.
+    """
+    if "$ref" in schema:
+        ref_value = schema.pop("$ref")
+        description = schema.pop("description", None)
+        schema["anyOf"] = [{"$ref": ref_value}, {"type": "null"}]
+        if description is not None:
+            schema["description"] = description
+        return
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, str):
+        schema["type"] = [schema_type, "null"]
+    elif isinstance(schema_type, list) and "null" not in schema_type:
+        schema["type"] = [*schema_type, "null"]
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and None not in enum_values:
+        schema["enum"] = [*enum_values, None]
+
+
 def __try_get_underlying_types_from_union(t: TypeLike) -> tuple[TypeLike, ...] | None:
     origin = get_origin(t)
     if origin is None:
@@ -214,22 +241,23 @@ def __convert_field_to_json_schema(
     underlying_union_types = __try_get_underlying_types_from_union(field_type)
     if underlying_union_types is not None:
         non_none_types = [t for t in underlying_union_types if t is not types.NoneType]
+        has_none = len(non_none_types) != len(underlying_union_types)
+
         if len(non_none_types) == 1:
-            field_type = non_none_types[0]
-            origin = get_origin(field_type)
-            if origin is Literal:
-                literal_values = get_args(field_type)
-                if literal_values and all(isinstance(v, str) for v in literal_values):
-                    schema["type"] = "string"
-                elif literal_values and all(isinstance(v, bool) for v in literal_values):
-                    schema["type"] = "boolean"
-                elif literal_values and all(isinstance(v, int) and not isinstance(v, bool) for v in literal_values):
-                    schema["type"] = "integer"
-                schema["enum"] = [v.value if isinstance(v, enum.Enum) else v for v in literal_values]
-                return schema
-        elif len(non_none_types) > 1:
-            schemas = [__convert_field_to_json_schema(t, EMPTY_METADATA, context) for t in non_none_types]
-            schema["anyOf"] = schemas
+            inner = __convert_field_to_json_schema(non_none_types[0], metadata, context)
+            for k, v in inner.items():
+                if k == "description" and "description" in schema:
+                    continue
+                schema[k] = v
+            if has_none:
+                __add_null_branch(schema)
+            return schema
+
+        if len(non_none_types) > 1:
+            branches = [__convert_field_to_json_schema(t, EMPTY_METADATA, context) for t in non_none_types]
+            if has_none:
+                branches.append({"type": "null"})
+            schema["anyOf"] = branches
             return schema
 
     if field_type is str:

--- a/python/marshmallow_recipe/json_schema.py
+++ b/python/marshmallow_recipe/json_schema.py
@@ -126,8 +126,18 @@ def __make_nullable(schema: dict[str, Any]) -> dict[str, Any]:
         result["anyOf"] = [{"$ref": schema["$ref"]}, {"type": "null"}]
         return result
 
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        result = dict(schema)
+        if not any(isinstance(b, dict) and b.get("type") == "null" for b in any_of):
+            result["anyOf"] = [*any_of, {"type": "null"}]
+        return result
+
+    if "type" not in schema:
+        raise ValueError(f"cannot make schema nullable, no $ref / type / anyOf: {schema!r}")
+
     result = dict(schema)
-    schema_type = result.get("type")
+    schema_type = result["type"]
     if isinstance(schema_type, str):
         result["type"] = [schema_type, "null"]
     elif isinstance(schema_type, list) and "null" not in schema_type:

--- a/python/marshmallow_recipe/json_schema.py
+++ b/python/marshmallow_recipe/json_schema.py
@@ -120,31 +120,24 @@ def __is_optional(field_type: TypeLike) -> bool:
     return any(t is types.NoneType for t in underlying_union_types)
 
 
-def __add_null_branch(schema: dict[str, Any]) -> None:
-    """Mutate `schema` in place to also accept JSON null.
-
-    For ``$ref`` schemas, rewrites to ``anyOf`` because the 2020-12 spec
-    forbids siblings on a $ref-only schema. For typed schemas, appends
-    ``"null"`` to the ``type`` list and ``None`` to ``enum`` when present —
-    validators check ``type`` and ``enum`` independently.
-    """
+def __make_nullable(schema: dict[str, Any]) -> dict[str, Any]:
     if "$ref" in schema:
-        ref_value = schema.pop("$ref")
-        description = schema.pop("description", None)
-        schema["anyOf"] = [{"$ref": ref_value}, {"type": "null"}]
-        if description is not None:
-            schema["description"] = description
-        return
+        result = {k: v for k, v in schema.items() if k != "$ref"}
+        result["anyOf"] = [{"$ref": schema["$ref"]}, {"type": "null"}]
+        return result
 
-    schema_type = schema.get("type")
+    result = dict(schema)
+    schema_type = result.get("type")
     if isinstance(schema_type, str):
-        schema["type"] = [schema_type, "null"]
+        result["type"] = [schema_type, "null"]
     elif isinstance(schema_type, list) and "null" not in schema_type:
-        schema["type"] = [*schema_type, "null"]
+        result["type"] = [*schema_type, "null"]
 
-    enum_values = schema.get("enum")
+    enum_values = result.get("enum")
     if isinstance(enum_values, list) and None not in enum_values:
-        schema["enum"] = [*enum_values, None]
+        result["enum"] = [*enum_values, None]
+
+    return result
 
 
 def __try_get_underlying_types_from_union(t: TypeLike) -> tuple[TypeLike, ...] | None:
@@ -245,13 +238,7 @@ def __convert_field_to_json_schema(
 
         if len(non_none_types) == 1:
             inner = __convert_field_to_json_schema(non_none_types[0], metadata, context)
-            for k, v in inner.items():
-                if k == "description" and "description" in schema:
-                    continue
-                schema[k] = v
-            if has_none:
-                __add_null_branch(schema)
-            return schema
+            return __make_nullable(inner) if has_none else inner
 
         if len(non_none_types) > 1:
             branches = [__convert_field_to_json_schema(t, EMPTY_METADATA, context) for t in non_none_types]

--- a/python/marshmallow_recipe/json_schema.py
+++ b/python/marshmallow_recipe/json_schema.py
@@ -120,34 +120,46 @@ def __is_optional(field_type: TypeLike) -> bool:
     return any(t is types.NoneType for t in underlying_union_types)
 
 
-def __make_nullable(schema: dict[str, Any]) -> dict[str, Any]:
-    if "$ref" in schema:
-        result = {k: v for k, v in schema.items() if k != "$ref"}
-        result["anyOf"] = [{"$ref": schema["$ref"]}, {"type": "null"}]
-        return result
+__SCALAR_FORMATS: dict[Any, tuple[str, str | None]] = {
+    bool: ("boolean", None),
+    datetime.datetime: ("string", "date-time"),
+    datetime.date: ("string", "date"),
+    datetime.time: ("string", "time"),
+    uuid.UUID: ("string", "uuid"),
+    bytes: ("string", "byte"),
+}
 
-    any_of = schema.get("anyOf")
-    if isinstance(any_of, list):
-        result = dict(schema)
-        if not any(isinstance(b, dict) and b.get("type") == "null" for b in any_of):
-            result["anyOf"] = [*any_of, {"type": "null"}]
-        return result
 
-    if "type" not in schema:
-        raise ValueError(f"cannot make schema nullable, no $ref / type / anyOf: {schema!r}")
+def __nullable_type(name: str, nullable: bool) -> str | list[str]:
+    return [name, "null"] if nullable else name
 
-    result = dict(schema)
-    schema_type = result["type"]
-    if isinstance(schema_type, str):
-        result["type"] = [schema_type, "null"]
-    elif isinstance(schema_type, list) and "null" not in schema_type:
-        result["type"] = [*schema_type, "null"]
 
-    enum_values = result.get("enum")
-    if isinstance(enum_values, list) and None not in enum_values:
-        result["enum"] = [*enum_values, None]
+def __item_metadata(metadata: Metadata) -> Metadata:
+    item_description = metadata.get("item_description")
+    if item_description:
+        return Metadata({"description": item_description})
+    return EMPTY_METADATA
 
-    return result
+
+def __apply_length(schema: dict[str, Any], metadata: Metadata, *, item: bool) -> None:
+    min_length = metadata.get("min_length")
+    max_length = metadata.get("max_length")
+    if min_length is not None:
+        schema["minItems" if item else "minLength"] = min_length
+    if max_length is not None:
+        schema["maxItems" if item else "maxLength"] = max_length
+
+
+def __apply_numeric_bounds(schema: dict[str, Any], metadata: Metadata, *, stringify: bool) -> None:
+    for meta_key, schema_key in (
+        ("gt", "exclusiveMinimum"),
+        ("gte", "minimum"),
+        ("lt", "exclusiveMaximum"),
+        ("lte", "maximum"),
+    ):
+        value = metadata.get(meta_key)
+        if value is not None:
+            schema[schema_key] = str(value) if stringify else value
 
 
 def __try_get_underlying_types_from_union(t: TypeLike) -> tuple[TypeLike, ...] | None:
@@ -210,173 +222,163 @@ def __generate_dataclass_schema(
     return schema
 
 
-def __convert_field_to_json_schema(
-    field_type: TypeLike, metadata: Metadata, context: _JsonSchemaContext
+def __fill_literal_schema(schema: dict[str, Any], field_type: TypeLike, nullable: bool) -> None:
+    literal_values = get_args(field_type)
+    json_type: str | None = None
+    if literal_values and all(isinstance(v, str) for v in literal_values):
+        json_type = "string"
+    elif literal_values and all(isinstance(v, bool) for v in literal_values):
+        json_type = "boolean"
+    elif literal_values and all(isinstance(v, int) and not isinstance(v, bool) for v in literal_values):
+        json_type = "integer"
+    if json_type is not None:
+        schema["type"] = __nullable_type(json_type, nullable)
+    enum_values = [v.value if isinstance(v, enum.Enum) else v for v in literal_values]
+    schema["enum"] = [*enum_values, None] if nullable else enum_values
+
+
+def __fill_enum_schema(schema: dict[str, Any], enum_cls: type[enum.Enum], nullable: bool) -> None:
+    first_value = next(iter(enum_cls.__members__.values())).value
+    if isinstance(first_value, str):
+        json_type = "string"
+    elif isinstance(first_value, int):
+        json_type = "integer"
+    else:
+        json_type = "string"
+    schema["type"] = __nullable_type(json_type, nullable)
+    enum_values = [member.value for member in enum_cls.__members__.values()]
+    schema["enum"] = [*enum_values, None] if nullable else enum_values
+
+
+def __fill_ref_schema(
+    schema: dict[str, Any], field_type: TypeLike, context: _JsonSchemaContext, nullable: bool
+) -> None:
+    ref_name = __get_type_name(cast(type, field_type))
+    if field_type not in context.visited_types:
+        context.visited_types.add(field_type)
+        context.defs[ref_name] = __generate_dataclass_schema(cast(type, field_type), context)
+    ref = f"#/$defs/{ref_name}"
+    if nullable:
+        schema["anyOf"] = [{"$ref": ref}, {"type": "null"}]
+    else:
+        schema["$ref"] = ref
+
+
+def __build_leaf(
+    field_type: TypeLike, metadata: Metadata, context: _JsonSchemaContext, nullable: bool
 ) -> dict[str, Any]:
     schema: dict[str, Any] = {}
+    description = metadata.get("description")
+    if description:
+        schema["description"] = description
 
-    if metadata.get("description"):
-        schema["description"] = metadata["description"]
+    origin = get_origin(field_type)
 
+    if origin is Literal:
+        __fill_literal_schema(schema, field_type, nullable)
+        return schema
+
+    if field_type is str:
+        schema["type"] = __nullable_type("string", nullable)
+        __apply_length(schema, metadata, item=False)
+        return schema
+
+    if field_type is int:
+        schema["type"] = __nullable_type("integer", nullable)
+        __apply_numeric_bounds(schema, metadata, stringify=False)
+        return schema
+
+    if field_type is float:
+        schema["type"] = __nullable_type("number", nullable)
+        __apply_numeric_bounds(schema, metadata, stringify=False)
+        return schema
+
+    if field_type is decimal.Decimal:
+        schema["type"] = __nullable_type("string", nullable)
+        __apply_numeric_bounds(schema, metadata, stringify=True)
+        return schema
+
+    scalar = __SCALAR_FORMATS.get(field_type)
+    if scalar is not None:
+        json_type, fmt = scalar
+        schema["type"] = __nullable_type(json_type, nullable)
+        if fmt is not None:
+            schema["format"] = fmt
+        return schema
+
+    args = get_args(field_type)
+
+    if origin is list or origin is collections.abc.Sequence:
+        schema["type"] = __nullable_type("array", nullable)
+        if args:
+            schema["items"] = __convert_field_to_json_schema(args[0], __item_metadata(metadata), context)
+        __apply_length(schema, metadata, item=True)
+        return schema
+
+    if origin is set or origin is collections.abc.Set or origin is frozenset:
+        schema["type"] = __nullable_type("array", nullable)
+        schema["uniqueItems"] = True
+        if args:
+            schema["items"] = __convert_field_to_json_schema(args[0], __item_metadata(metadata), context)
+        return schema
+
+    if origin is tuple:
+        schema["type"] = __nullable_type("array", nullable)
+        if args and len(args) == 2 and args[1] is Ellipsis:
+            schema["items"] = __convert_field_to_json_schema(args[0], __item_metadata(metadata), context)
+        return schema
+
+    if origin is dict or origin is collections.abc.Mapping:
+        schema["type"] = __nullable_type("object", nullable)
+        if args and len(args) >= 2 and args[1] is not types.NoneType:
+            schema["additionalProperties"] = __convert_field_to_json_schema(args[1], EMPTY_METADATA, context)
+        return schema
+
+    field_origin = origin or field_type
+    if isinstance(field_origin, type) and dataclasses.is_dataclass(field_origin):
+        __fill_ref_schema(schema, field_type, context, nullable)
+        return schema
+
+    if isinstance(field_origin, type) and issubclass(field_origin, enum.Enum):
+        __fill_enum_schema(schema, field_origin, nullable)
+        return schema
+
+    schema["type"] = __nullable_type("object", nullable)
+    return schema
+
+
+def __convert_field_to_json_schema(
+    field_type: TypeLike, metadata: Metadata, context: _JsonSchemaContext, *, nullable: bool = False
+) -> dict[str, Any]:
     while isinstance(field_type, TypeAliasType):
         field_type = field_type.__value__
 
-    origin = get_origin(field_type)
-    if origin is Annotated:
+    if get_origin(field_type) is Annotated:
         args = get_args(field_type)
         if args:
             underlying_type = args[0]
             annotated_metadata = next((arg for arg in args[1:] if isinstance(arg, Metadata)), EMPTY_METADATA)
             merged_metadata = Metadata(dict(metadata, **annotated_metadata))
-            return __convert_field_to_json_schema(underlying_type, merged_metadata, context)
-
-    if origin is Literal:
-        literal_values = get_args(field_type)
-        if literal_values and all(isinstance(v, str) for v in literal_values):
-            schema["type"] = "string"
-        elif literal_values and all(isinstance(v, bool) for v in literal_values):
-            schema["type"] = "boolean"
-        elif literal_values and all(isinstance(v, int) and not isinstance(v, bool) for v in literal_values):
-            schema["type"] = "integer"
-        schema["enum"] = [v.value if isinstance(v, enum.Enum) else v for v in literal_values]
-        return schema
+            return __convert_field_to_json_schema(underlying_type, merged_metadata, context, nullable=nullable)
 
     underlying_union_types = __try_get_underlying_types_from_union(field_type)
     if underlying_union_types is not None:
         non_none_types = [t for t in underlying_union_types if t is not types.NoneType]
-        has_none = len(non_none_types) != len(underlying_union_types)
+        nullable = nullable or len(non_none_types) != len(underlying_union_types)
 
         if len(non_none_types) == 1:
-            inner = __convert_field_to_json_schema(non_none_types[0], metadata, context)
-            return __make_nullable(inner) if has_none else inner
+            return __convert_field_to_json_schema(non_none_types[0], metadata, context, nullable=nullable)
 
-        if len(non_none_types) > 1:
-            branches = [__convert_field_to_json_schema(t, EMPTY_METADATA, context) for t in non_none_types]
-            if has_none:
-                branches.append({"type": "null"})
-            schema["anyOf"] = branches
+        schema: dict[str, Any] = {}
+        if metadata.get("description"):
+            schema["description"] = metadata["description"]
+        if not non_none_types:
+            schema["type"] = "null"
             return schema
+        branches = [__convert_field_to_json_schema(t, EMPTY_METADATA, context) for t in non_none_types]
+        if nullable:
+            branches.append({"type": "null"})
+        schema["anyOf"] = branches
+        return schema
 
-    if field_type is str:
-        schema["type"] = "string"
-        if metadata.get("min_length") is not None:
-            schema["minLength"] = metadata["min_length"]
-        if metadata.get("max_length") is not None:
-            schema["maxLength"] = metadata["max_length"]
-    elif field_type is int:
-        schema["type"] = "integer"
-        if metadata.get("gt") is not None:
-            schema["exclusiveMinimum"] = metadata["gt"]
-        if metadata.get("gte") is not None:
-            schema["minimum"] = metadata["gte"]
-        if metadata.get("lt") is not None:
-            schema["exclusiveMaximum"] = metadata["lt"]
-        if metadata.get("lte") is not None:
-            schema["maximum"] = metadata["lte"]
-    elif field_type is float:
-        schema["type"] = "number"
-        if metadata.get("gt") is not None:
-            schema["exclusiveMinimum"] = metadata["gt"]
-        if metadata.get("gte") is not None:
-            schema["minimum"] = metadata["gte"]
-        if metadata.get("lt") is not None:
-            schema["exclusiveMaximum"] = metadata["lt"]
-        if metadata.get("lte") is not None:
-            schema["maximum"] = metadata["lte"]
-    elif field_type is bool:
-        schema["type"] = "boolean"
-    elif field_type is datetime.datetime:
-        schema["type"] = "string"
-        schema["format"] = "date-time"
-    elif field_type is datetime.date:
-        schema["type"] = "string"
-        schema["format"] = "date"
-    elif field_type is datetime.time:
-        schema["type"] = "string"
-        schema["format"] = "time"
-    elif field_type is uuid.UUID:
-        schema["type"] = "string"
-        schema["format"] = "uuid"
-    elif field_type is bytes:
-        schema["type"] = "string"
-        schema["format"] = "byte"
-    elif field_type is decimal.Decimal:
-        schema["type"] = "string"
-        if metadata.get("gt") is not None:
-            schema["exclusiveMinimum"] = str(metadata["gt"])
-        if metadata.get("gte") is not None:
-            schema["minimum"] = str(metadata["gte"])
-        if metadata.get("lt") is not None:
-            schema["exclusiveMaximum"] = str(metadata["lt"])
-        if metadata.get("lte") is not None:
-            schema["maximum"] = str(metadata["lte"])
-    else:
-        origin = get_origin(field_type)
-        if origin is not None:
-            args = get_args(field_type)
-            if origin is list or origin is collections.abc.Sequence:
-                schema["type"] = "array"
-                if args:
-                    item_meta = EMPTY_METADATA
-                    if metadata.get("item_description"):
-                        item_meta = Metadata({"description": metadata["item_description"]})
-                    schema["items"] = __convert_field_to_json_schema(args[0], item_meta, context)
-                if metadata.get("min_length") is not None:
-                    schema["minItems"] = metadata["min_length"]
-                if metadata.get("max_length") is not None:
-                    schema["maxItems"] = metadata["max_length"]
-            elif origin is set or origin is collections.abc.Set or origin is frozenset:
-                schema["type"] = "array"
-                schema["uniqueItems"] = True
-                if args:
-                    item_meta = EMPTY_METADATA
-                    if metadata.get("item_description"):
-                        item_meta = Metadata({"description": metadata["item_description"]})
-                    schema["items"] = __convert_field_to_json_schema(args[0], item_meta, context)
-            elif origin is tuple:
-                schema["type"] = "array"
-                if args and len(args) == 2 and args[1] is Ellipsis:
-                    item_meta = EMPTY_METADATA
-                    if metadata.get("item_description"):
-                        item_meta = Metadata({"description": metadata["item_description"]})
-                    schema["items"] = __convert_field_to_json_schema(args[0], item_meta, context)
-            elif origin is dict or origin is collections.abc.Mapping:
-                schema["type"] = "object"
-                if args and len(args) >= 2 and args[1] is not type(None):
-                    schema["additionalProperties"] = __convert_field_to_json_schema(args[1], EMPTY_METADATA, context)
-            elif isinstance(origin, type) and dataclasses.is_dataclass(origin):
-                # Subscripted generic dataclass like Container[int]
-                ref_name = __get_type_name(cast(type, field_type))
-                if field_type not in context.visited_types:
-                    context.visited_types.add(field_type)
-                    nested_schema = __generate_dataclass_schema(cast(type, field_type), context)
-                    context.defs[ref_name] = nested_schema
-                schema["$ref"] = f"#/$defs/{ref_name}"
-            else:
-                schema["type"] = "object"
-        else:
-            # Check if it's a dataclass (non-generic or base case)
-            field_origin = get_origin(field_type) or field_type
-            if isinstance(field_origin, type) and dataclasses.is_dataclass(field_origin):
-                ref_name = __get_type_name(cast(type, field_type))
-                # Add to visited_types first to prevent infinite recursion on cyclic references
-                if field_type not in context.visited_types:
-                    context.visited_types.add(field_type)
-                    # Generate the nested schema using internal helper to pass context
-                    nested_schema = __generate_dataclass_schema(cast(type, field_type), context)
-                    context.defs[ref_name] = nested_schema
-                # Always set $ref, even if we already processed this type
-                schema["$ref"] = f"#/$defs/{ref_name}"
-            elif isinstance(field_origin, type) and issubclass(field_origin, enum.Enum):
-                first_value = next(iter(field_origin.__members__.values())).value
-                if isinstance(first_value, str):
-                    schema["type"] = "string"
-                elif isinstance(first_value, int):
-                    schema["type"] = "integer"
-                else:
-                    schema["type"] = "string"
-                schema["enum"] = [member.value for member in field_origin.__members__.values()]
-            else:
-                schema["type"] = "object"
-
-    return schema
+    return __build_leaf(field_type, metadata, context, nullable)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -56,8 +56,8 @@ def test_optional_fields() -> None:
         "title": "OptionalFields",
         "properties": {
             "required_str": {"type": "string"},
-            "optional_str": {"type": "string"},
-            "optional_int": {"type": "integer"},
+            "optional_str": {"type": ["string", "null"]},
+            "optional_int": {"type": ["integer", "null"]},
         },
         "required": ["required_str"],
     }
@@ -482,7 +482,10 @@ def test_cyclic_references() -> None:
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "title": "_CyclicNode",
-        "properties": {"value": {"type": "integer"}, "next_node": {"$ref": "#/$defs/_CyclicNode", "default": None}},
+        "properties": {
+            "value": {"type": "integer"},
+            "next_node": {"anyOf": [{"$ref": "#/$defs/_CyclicNode"}, {"type": "null"}], "default": None},
+        },
         "required": ["value"],
         "$defs": {
             "_CyclicNode": {
@@ -490,7 +493,7 @@ def test_cyclic_references() -> None:
                 "title": "_CyclicNode",
                 "properties": {
                     "value": {"type": "integer"},
-                    "next_node": {"$ref": "#/$defs/_CyclicNode", "default": None},
+                    "next_node": {"anyOf": [{"$ref": "#/$defs/_CyclicNode"}, {"type": "null"}], "default": None},
                 },
                 "required": ["value"],
             }
@@ -507,7 +510,7 @@ def test_mutually_recursive_types() -> None:
         "title": "_RecursivePerson",
         "properties": {
             "name": {"type": "string"},
-            "spouse": {"$ref": "#/$defs/_RecursivePerson", "default": None},
+            "spouse": {"anyOf": [{"$ref": "#/$defs/_RecursivePerson"}, {"type": "null"}], "default": None},
             "friends": {"type": "array", "items": {"$ref": "#/$defs/_RecursivePerson"}},
         },
         "required": ["name"],
@@ -517,7 +520,7 @@ def test_mutually_recursive_types() -> None:
                 "title": "_RecursivePerson",
                 "properties": {
                     "name": {"type": "string"},
-                    "spouse": {"$ref": "#/$defs/_RecursivePerson", "default": None},
+                    "spouse": {"anyOf": [{"$ref": "#/$defs/_RecursivePerson"}, {"type": "null"}], "default": None},
                     "friends": {"type": "array", "items": {"$ref": "#/$defs/_RecursivePerson"}},
                 },
                 "required": ["name"],
@@ -557,7 +560,11 @@ def test_enum_types() -> None:
             "title": {"type": "string"},
             "status": {"type": "string", "enum": ["active", "inactive", "pending"]},
             "priority": {"type": "integer", "enum": [1, 2, 3]},
-            "optional_status": {"type": "string", "enum": ["active", "inactive", "pending"], "default": None},
+            "optional_status": {
+                "type": ["string", "null"],
+                "enum": ["active", "inactive", "pending", None],
+                "default": None,
+            },
         },
         "required": ["title", "status", "priority"],
     }
@@ -678,7 +685,12 @@ def test_set_and_frozenset_types() -> None:
         "properties": {
             "tags_set": {"type": "array", "uniqueItems": True, "items": {"type": "string"}},
             "ids_frozenset": {"type": "array", "uniqueItems": True, "items": {"type": "integer"}},
-            "optional_set": {"type": "array", "uniqueItems": True, "items": {"type": "string"}, "default": None},
+            "optional_set": {
+                "type": ["array", "null"],
+                "uniqueItems": True,
+                "items": {"type": "string"},
+                "default": None,
+            },
         },
         "required": ["tags_set", "ids_frozenset"],
     }
@@ -700,7 +712,7 @@ def test_dict_types() -> None:
         "properties": {
             "simple_dict": {"type": "object", "additionalProperties": {"type": "integer"}},
             "any_dict": {"type": "object", "additionalProperties": {"type": "object"}},
-            "optional_dict": {"type": "object", "additionalProperties": {"type": "string"}, "default": None},
+            "optional_dict": {"type": ["object", "null"], "additionalProperties": {"type": "string"}, "default": None},
         },
         "required": ["simple_dict", "any_dict"],
     }
@@ -858,9 +870,9 @@ def test_literal_types() -> None:
             "str_literal": {"type": "string", "enum": ["a", "b", "c"]},
             "int_literal": {"type": "integer", "enum": [1, 2, 3]},
             "bool_literal": {"type": "boolean", "enum": [True, False]},
-            "optional_str_literal": {"type": "string", "enum": ["x", "y"], "default": None},
-            "optional_int_literal": {"type": "integer", "enum": [1, 2], "default": None},
-            "optional_bool_literal": {"type": "boolean", "enum": [True], "default": None},
+            "optional_str_literal": {"type": ["string", "null"], "enum": ["x", "y", None], "default": None},
+            "optional_int_literal": {"type": ["integer", "null"], "enum": [1, 2, None], "default": None},
+            "optional_bool_literal": {"type": ["boolean", "null"], "enum": [True, None], "default": None},
         },
         "required": ["str_literal", "int_literal", "bool_literal"],
     }
@@ -896,7 +908,7 @@ def test_literal_enum_member_types() -> None:
             "str_enum_single": {"type": "string", "enum": ["DOG"]},
             "int_enum_multi": {"type": "integer", "enum": [1, 2]},
             "int_enum_single": {"type": "integer", "enum": [1]},
-            "optional_str_enum": {"type": "string", "enum": ["DOG"], "default": None},
+            "optional_str_enum": {"type": ["string", "null"], "enum": ["DOG", None], "default": None},
         },
         "required": ["str_enum_multi", "str_enum_single", "int_enum_multi", "int_enum_single"],
     }
@@ -916,7 +928,7 @@ def test_bytes_field() -> None:
         "title": "WithBytes",
         "properties": {
             "data": {"type": "string", "format": "byte"},
-            "optional_data": {"type": "string", "format": "byte", "default": None},
+            "optional_data": {"type": ["string", "null"], "format": "byte", "default": None},
         },
         "required": ["data"],
     }
@@ -944,7 +956,7 @@ def test_type_alias() -> None:
         "title": "WithTypeAliases",
         "properties": {
             "name": {"type": "string"},
-            "count": {"type": "integer", "default": None},
+            "count": {"type": ["integer", "null"], "default": None},
             "value": {"anyOf": [{"type": "string"}, {"type": "integer"}], "default": "default"},
         },
         "required": ["name"],
@@ -976,6 +988,83 @@ def test_type_alias_union_of_aliases() -> None:
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
         "title": "WithUnionOfAliases",
-        "properties": {"value": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
+        "properties": {"value": {"anyOf": [{"type": "string"}, {"type": ["integer", "null"]}]}},
         "required": ["value"],
     }
+
+
+def test_optional_multi_union_appends_null_branch() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class M:
+        v: int | str | None = None
+
+    schema = mr.json_schema(M)
+    assert schema == {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": "M",
+        "properties": {"v": {"anyOf": [{"type": "integer"}, {"type": "string"}, {"type": "null"}], "default": None}},
+        "required": [],
+    }
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class _NullableInner:
+    v: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class _NullableOuter:
+    inner: _NullableInner | None = None
+
+
+def test_optional_dataclass_renders_anyof_with_null() -> None:
+    schema = mr.json_schema(_NullableOuter)
+    assert schema == {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": "_NullableOuter",
+        "properties": {"inner": {"anyOf": [{"$ref": "#/$defs/_NullableInner"}, {"type": "null"}], "default": None}},
+        "required": [],
+        "$defs": {
+            "_NullableInner": {
+                "type": "object",
+                "title": "_NullableInner",
+                "properties": {"v": {"type": "integer"}},
+                "required": ["v"],
+            }
+        },
+    }
+
+
+class _NullableEnumStatus(enum.StrEnum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+def test_optional_enum_includes_null_in_type_and_enum_list() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class M:
+        status: _NullableEnumStatus | None = None
+
+    schema = mr.json_schema(M)
+    assert schema == {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": "M",
+        "properties": {"status": {"type": ["string", "null"], "enum": ["active", "inactive", None], "default": None}},
+        "required": [],
+    }
+
+
+def test_none_value_handling_does_not_change_json_schema_shape() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class M:
+        s: str | None = None
+
+    default = mr.json_schema(M)
+    ignore = mr.json_schema(M, none_value_handling=mr.NoneValueHandling.IGNORE)
+    include = mr.json_schema(M, none_value_handling=mr.NoneValueHandling.INCLUDE)
+
+    assert default == ignore == include
+    assert default["properties"]["s"] == {"type": ["string", "null"], "default": None}

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -5,7 +5,7 @@ import datetime
 import decimal
 import enum
 import uuid
-from typing import Annotated, Generic, Literal, TypeVar
+from typing import Annotated, Any, Generic, Literal, TypeVar
 
 import pytest
 
@@ -1084,3 +1084,74 @@ def test_none_value_handling_does_not_change_json_schema_shape() -> None:
 
     assert default == ignore == include
     assert default["properties"]["s"] == {"type": ["string", "null"], "default": None}
+
+
+def _assert_nullable_property(inner_annotation: Any, expected_property: dict[str, object]) -> None:
+    cls = dataclasses.make_dataclass("M", [("v", inner_annotation | None)], frozen=True, slots=True, kw_only=True)
+    assert mr.json_schema(cls) == {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": "M",
+        "properties": {"v": expected_property},
+        "required": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("meta", "expected_extra"),
+    [
+        (mr.str_meta(min_length=1, max_length=5), {"minLength": 1, "maxLength": 5}),
+        (mr.str_meta(min_length=2), {"minLength": 2}),
+        (mr.str_meta(max_length=5), {"maxLength": 5}),
+    ],
+)
+def test_nullable_str_keeps_length_constraints(meta: Any, expected_extra: dict[str, object]) -> None:
+    _assert_nullable_property(Annotated[str, meta], {"type": ["string", "null"], **expected_extra})
+
+
+@pytest.mark.parametrize(
+    ("inner_annotation", "expected_property"),
+    [
+        (Annotated[int, mr.int_meta(gte=1, lte=9)], {"type": ["integer", "null"], "minimum": 1, "maximum": 9}),
+        (
+            Annotated[int, mr.int_meta(gt=0, lt=100)],
+            {"type": ["integer", "null"], "exclusiveMinimum": 0, "exclusiveMaximum": 100},
+        ),
+        (
+            Annotated[float, mr.float_meta(gte=0.0, lte=1.0)],
+            {"type": ["number", "null"], "minimum": 0.0, "maximum": 1.0},
+        ),
+        (
+            Annotated[float, mr.float_meta(gt=0.0, lt=10.0)],
+            {"type": ["number", "null"], "exclusiveMinimum": 0.0, "exclusiveMaximum": 10.0},
+        ),
+    ],
+)
+def test_nullable_numeric_keeps_bounds(inner_annotation: Any, expected_property: dict[str, object]) -> None:
+    _assert_nullable_property(inner_annotation, expected_property)
+
+
+@pytest.mark.parametrize(
+    ("meta", "expected_extra"),
+    [
+        (mr.decimal_meta(gte=0, lte=100), {"minimum": "0", "maximum": "100"}),
+        (mr.decimal_meta(gt=0), {"exclusiveMinimum": "0"}),
+        (mr.decimal_meta(lt=1000), {"exclusiveMaximum": "1000"}),
+    ],
+)
+def test_nullable_decimal_keeps_stringified_bounds(meta: Any, expected_extra: dict[str, object]) -> None:
+    _assert_nullable_property(Annotated[decimal.Decimal, meta], {"type": ["string", "null"], **expected_extra})
+
+
+@pytest.mark.parametrize(
+    ("meta", "expected_extra"),
+    [
+        (mr.list_meta(min_length=1, max_length=3), {"minItems": 1, "maxItems": 3}),
+        (mr.list_meta(min_length=2), {"minItems": 2}),
+        (mr.list_meta(max_length=5), {"maxItems": 5}),
+    ],
+)
+def test_nullable_list_keeps_item_count_constraints(meta: Any, expected_extra: dict[str, object]) -> None:
+    _assert_nullable_property(
+        Annotated[list[int], meta], {"type": ["array", "null"], "items": {"type": "integer"}, **expected_extra}
+    )

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -939,6 +939,7 @@ type OptionalIntAlias = int | None
 type UnionAlias = str | int
 type ChainedStrAlias = StrAlias
 type UnionOfAliases = StrAlias | OptionalIntAlias
+type IntOrStrAlias = int | str
 
 
 def test_type_alias() -> None:
@@ -997,6 +998,21 @@ def test_optional_multi_union_appends_null_branch() -> None:
     @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
     class M:
         v: int | str | None = None
+
+    schema = mr.json_schema(M)
+    assert schema == {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "title": "M",
+        "properties": {"v": {"anyOf": [{"type": "integer"}, {"type": "string"}, {"type": "null"}], "default": None}},
+        "required": [],
+    }
+
+
+def test_optional_type_alias_to_multi_union_appends_null_branch() -> None:
+    @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+    class M:
+        v: IntOrStrAlias | None = None
 
     schema = mr.json_schema(M)
     assert schema == {


### PR DESCRIPTION
## Summary

- `mr.json_schema()` now renders `T | None` as nullable JSON Schema. Previously the `None` branch was dropped, producing schemas that rejected `null` even though the Python type allowed it.
- `NoneValueHandling` is now strictly serialization-only — it no longer affects schema shape. The schema describes valid input, and `null` is valid whenever the Python type is `T | None`.

## Mapping

| Python type | JSON Schema |
|---|---|
| `str \| None` | `{"type": ["string", "null"]}` |
| `int \| str \| None` | `{"anyOf": [{"type": "integer"}, {"type": "string"}, {"type": "null"}]}` |
| `Nested \| None` | `{"anyOf": [{"$ref": "#/$defs/Nested"}, {"type": "null"}]}` |
| `Literal["a", "b"] \| None` | `{"type": ["string", "null"], "enum": ["a", "b", null]}` |
| `MyEnum \| None` | `{"type": ["string", "null"], "enum": [..., null]}` |

Nested/self-referential dataclasses use `anyOf` instead of `$ref` + sibling keys: a sibling `type: null` next to `$ref` is conjunctive (ref AND null → unsatisfiable), so `anyOf` expresses the union. (Sibling keywords are allowed in 2020-12 — `$ref` is an applicator — they're just the wrong tool here.) For nullable enums and `Literal`, `null` appears in both the `type` list and the `enum` list — validators check them independently.

## Implementation

Nullability is threaded as a flag down the conversion recursion, so every leaf builds its correct nullable shape directly — there is no post-build pass that inspects and rewrites an already-built schema dict. Scalar types share a small `__SCALAR_FORMATS` mapping, and length / numeric-bound constraints are applied through shared helpers.

## Breaking Changes

JSON Schema output for any optional field changes shape. Downstream consumers that relied on the previous (incorrect) non-nullable schemas will need to accept the new nullable shape. The Python loading/dumping behavior is unchanged.

## Test Plan

- [x] `make lint` — clean
- [x] `make test` — 10307 passed, 43 skipped
- [x] Tests cover: multi-branch union with `None`, nullable dataclass `$ref`, nullable enum, `NoneValueHandling` independence, and nullable fields combined with constraints (str length, int/float bounds, Decimal bounds, list item counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
