### PR TITLE
Add bytes-level JSON parser and dump_to_bytes to nuked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.99 (2026-06-08)
+
+* [Add bytes-level JSON parser and `dump_to_bytes` to `nuked`](https://github.com/anna-money/marshmallow-recipe/pull/307)
+
+
 ## v0.0.98 (2026-05-29)
 
 * **Breaking:** `mr.json_schema()` now renders `T | None` as nullable JSON Schema. `str | None` becomes `{"type": ["string", "null"]}`; `Nested | None` becomes `{"anyOf": [{"$ref": "#/$defs/Nested"}, {"type": "null"}]}`; nullable enums and `Literal` types include `null` in both the `type` list and the `enum` list. Previously the `None` branch was dropped, producing schemas that rejected `null` even though the Python type allowed it. `NoneValueHandling` does not affect schema rendering — it remains a serialization-only setting.

--- a/python/marshmallow_recipe/nuked/__init__.py
+++ b/python/marshmallow_recipe/nuked/__init__.py
@@ -34,7 +34,7 @@ from ..missing import MISSING
 from ..options import NoneValueHandling, try_get_options_for
 from ..utils import validate_decimal_places
 
-__all__ = ("dump", "load", "schema")
+__all__ = ("dump", "dump_to_bytes", "load", "load_from_bytes", "schema")
 
 _MARSHMALLOW_VERSION_MAJOR = int(importlib.metadata.version("marshmallow").split(".")[0])
 
@@ -981,6 +981,35 @@ def dump[T](
     return container.dump(data)
 
 
+def dump_to_bytes[T](
+    cls: type[T],
+    data: T,
+    *,
+    naming_case: NamingCase | None = None,
+    none_value_handling: NoneValueHandling | None = None,
+    decimal_places: int | None = MISSING,
+) -> bytes:
+    """Serialize to JSON bytes using the Rust backend.
+
+    Writes JSON straight into a byte buffer, skipping the intermediate Python
+    dict/list tree and the separate ``json.dumps`` pass. Byte output matches
+    ``json.dumps(mr.nuked.dump(cls, data), separators=(",", ":")).encode()``.
+
+    Args:
+        cls: Dataclass type or root collection type (e.g. ``list[User]``, ``dict[str, User]``).
+        data: Instance to serialize.
+        naming_case: Convert field names. Use ``mr.CAMEL_CASE``,
+            ``mr.CAPITAL_CAMEL_CASE``, or ``mr.UPPER_SNAKE_CASE``.
+        none_value_handling: Controls None field output.
+            ``mr.NoneValueHandling.INCLUDE`` keeps None fields, default excludes them.
+        decimal_places: Validate maximum decimal places for all Decimal fields.
+    """
+    validate_decimal_places(decimal_places)
+
+    container = _get_container(cls, naming_case, none_value_handling, decimal_places)
+    return container.dump_to_bytes(data)
+
+
 def load[T](
     cls: type[T], data: Any, *, naming_case: NamingCase | None = None, decimal_places: int | None = MISSING
 ) -> T:
@@ -1000,6 +1029,28 @@ def load[T](
 
     container = _get_container(cls, naming_case, NoneValueHandling.IGNORE, decimal_places)
     return container.load(data)  # type: ignore[return-value]
+
+
+def load_from_bytes[T](
+    cls: type[T], data: bytes, *, naming_case: NamingCase | None = None, decimal_places: int | None = MISSING
+) -> T:
+    """Deserialize from JSON bytes using the Rust backend.
+
+    Parses JSON straight into the target dataclass, skipping the intermediate
+    ``json.loads`` dict and the separate ``load`` pass. Produces the same objects
+    and ``marshmallow.ValidationError`` messages as ``mr.nuked.load(cls, json.loads(data))``.
+
+    Args:
+        cls: Dataclass type or root collection type (e.g. ``list[User]``, ``dict[str, User]``).
+        data: JSON bytes to deserialize (UTF-8).
+        naming_case: Convert field names. Use ``mr.CAMEL_CASE``,
+            ``mr.CAPITAL_CAMEL_CASE``, or ``mr.UPPER_SNAKE_CASE``.
+        decimal_places: Validate maximum decimal places for all Decimal fields.
+    """
+    validate_decimal_places(decimal_places)
+
+    container = _get_container(cls, naming_case, NoneValueHandling.IGNORE, decimal_places)
+    return container.load_from_bytes(data)  # type: ignore[return-value]
 
 
 SchemaKey = tuple[type, bool, NamingCase | None, NoneValueHandling | None, int | None]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyList, PyString, PyTuple};
+use pyo3::types::{PyBytes, PyList, PyString, PyTuple};
 
 use crate::container::{
     DataclassContainer, DataclassField, DataclassRegistry, FieldCommon, FieldContainer,
@@ -13,6 +13,7 @@ use crate::fields::datetime::parse_datetime_format;
 use crate::fields::decimal::get_decimal_cls;
 use crate::fields::length::LengthBound;
 use crate::fields::range::RangeBound;
+use crate::json::sink::DumpSink;
 
 #[pyclass]
 pub struct Container {
@@ -28,10 +29,36 @@ impl Container {
             .map_err(|e| e.to_validation_err(py))
     }
 
+    fn load_from_bytes(&self, py: Python<'_>, data: &[u8]) -> PyResult<Py<PyAny>> {
+        let mut parser = crate::json::parser::Parser::new(data);
+        let result = self
+            .inner
+            .load_from_bytes(py, &self.registry, &mut parser)
+            .map_err(|e| e.to_validation_err(py))?;
+        if !parser.at_end() {
+            return Err(crate::error::SerializationError::simple(
+                py,
+                "Invalid JSON: trailing data",
+            )
+            .to_validation_err(py));
+        }
+        Ok(result)
+    }
+
     fn dump(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        let mut sink = crate::json::sink::PyDictSink::new(py);
         self.inner
-            .dump_to_py(&self.registry, obj)
-            .map_err(|e| e.to_validation_err(py))
+            .dump(&self.registry, obj, &mut sink, None)
+            .map_err(|e| e.to_validation_err(py))?;
+        Ok(sink.finish())
+    }
+
+    fn dump_to_bytes(&self, py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Py<PyBytes>> {
+        let mut sink = crate::json::sink::JsonWriterSink::new();
+        self.inner
+            .dump(&self.registry, obj, &mut sink, None)
+            .map_err(|e| e.to_validation_err(py))?;
+        Ok(PyBytes::new(py, &sink.finish()).unbind())
     }
 }
 

--- a/src/container_dump.rs
+++ b/src/container_dump.rs
@@ -1,26 +1,216 @@
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyString};
 
 use crate::container::{DataclassContainer, DataclassRegistry, FieldContainer, TypeContainer};
 use crate::error::{SerializationError, accumulate_error, pyerrors_to_serialization_error};
+use crate::fields::collection::CollectionKind;
+use crate::fields::length::{LengthBound, validate_length};
 use crate::fields::{
-    any, bool_literal, bool_type, bytes, collection, date, datetime, decimal, dict, float_type,
-    int_enum, int_literal, int_type, str_enum, str_literal, str_type, time, union, uuid,
+    any, bool_literal, bool_type, bytes, date, datetime, decimal, float_type, int_enum,
+    int_literal, int_type, str_enum, str_literal, str_type, time, uuid,
 };
-use crate::utils::{call_validator, new_presized_list};
+use crate::json::sink::{DumpSink, PyDictSink, wrap_value_error};
+use crate::slots::get_slot_value_direct;
+use crate::utils::{call_validator, get_missing_sentinel};
 
-#[allow(clippy::cast_sign_loss, clippy::unused_self)]
+#[allow(clippy::too_many_arguments)]
+fn dump_collection<'py, S: DumpSink<'py>>(
+    registry: &DataclassRegistry,
+    value: &Bound<'py, PyAny>,
+    kind: CollectionKind,
+    item: &FieldContainer,
+    item_validator: Option<&Py<PyAny>>,
+    invalid_error: &Py<PyString>,
+    min_length: Option<&LengthBound>,
+    max_length: Option<&LengthBound>,
+    sink: &mut S,
+    key: Option<&str>,
+) -> Result<(), SerializationError> {
+    let py = value.py();
+
+    if !kind.is_valid_type(value) {
+        return Err(SerializationError::Single(invalid_error.clone_ref(py)));
+    }
+
+    let size = value
+        .len()
+        .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
+    validate_length(py, size, min_length, max_length)?;
+
+    sink.open_array(key, |s| {
+        let mut errors: Option<Bound<'_, PyDict>> = None;
+        let iter = value
+            .try_iter()
+            .map_err(|_| SerializationError::Single(invalid_error.clone_ref(py)))?;
+        for (idx, item_result) in iter.enumerate() {
+            let v = item_result.map_err(|e| SerializationError::simple(py, &e.to_string()))?;
+            if let Some(validator) = item_validator
+                && let Ok(Some(err_list)) = call_validator(py, validator, &v)
+            {
+                let e = pyerrors_to_serialization_error(py, &err_list);
+                accumulate_error(py, &mut errors, idx, &e);
+                continue;
+            }
+            match item.dump(registry, &v, s, None) {
+                Ok(true) => {}
+                Ok(false) => s.null(None)?,
+                Err(ref e) => accumulate_error(py, &mut errors, idx, e),
+            }
+        }
+        if let Some(errors) = errors {
+            return Err(SerializationError::Dict(errors.unbind()));
+        }
+        Ok(())
+    })
+}
+
+fn dump_dict<'py, S: DumpSink<'py>>(
+    registry: &DataclassRegistry,
+    value: &Bound<'py, PyAny>,
+    value_schema: &FieldContainer,
+    value_validator: Option<&Py<PyAny>>,
+    invalid_error: &Py<PyString>,
+    sink: &mut S,
+    key: Option<&str>,
+) -> Result<(), SerializationError> {
+    let py = value.py();
+    let dict = value
+        .cast::<PyDict>()
+        .map_err(|_| SerializationError::Single(invalid_error.clone_ref(py)))?;
+
+    sink.open_object(key, |s| {
+        let mut errors: Option<Bound<'_, PyDict>> = None;
+        for (k, v) in dict.iter() {
+            let key_obj = k.cast::<PyString>().map_err(|_| {
+                SerializationError::Single(
+                    intern!(py, "Dict key must be a string").clone().unbind(),
+                )
+            })?;
+            let key_str = key_obj
+                .to_str()
+                .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
+
+            if let Some(validator) = value_validator
+                && let Ok(Some(err_list)) = call_validator(py, validator, &v)
+            {
+                let e = pyerrors_to_serialization_error(py, &err_list);
+                accumulate_error(py, &mut errors, key_str, &e);
+                continue;
+            }
+
+            match value_schema.dump(registry, &v, s, Some(key_str)) {
+                Ok(true) => {}
+                Ok(false) => s.null(Some(key_str))?,
+                Err(ref e) => {
+                    accumulate_error(py, &mut errors, key_str, &wrap_value_error(py, e));
+                }
+            }
+        }
+        if let Some(errors) = errors {
+            return Err(SerializationError::Dict(errors.unbind()));
+        }
+        Ok(())
+    })
+}
+
 impl FieldContainer {
-    pub fn dump_to_py(
+    pub fn dump<'py, S: DumpSink<'py>>(
         &self,
         registry: &DataclassRegistry,
-        value: &Bound<'_, PyAny>,
-    ) -> Result<Py<PyAny>, SerializationError> {
+        value: &Bound<'py, PyAny>,
+        sink: &mut S,
+        key: Option<&str>,
+    ) -> Result<bool, SerializationError> {
+        let py = value.py();
         if value.is_none() {
-            return Ok(value.py().None());
+            return Ok(false);
         }
 
+        match self {
+            Self::Any { .. } => {
+                let v = any::dump_to_py(value)?;
+                sink.pyobject(key, v.bind(py))?;
+                Ok(true)
+            }
+            Self::Collection {
+                common,
+                kind,
+                item,
+                item_validator,
+                min_length,
+                max_length,
+            } => {
+                dump_collection(
+                    registry,
+                    value,
+                    *kind,
+                    item,
+                    item_validator.as_ref(),
+                    &common.invalid_error,
+                    min_length.as_ref(),
+                    max_length.as_ref(),
+                    sink,
+                    key,
+                )?;
+                Ok(true)
+            }
+            Self::Dict {
+                common,
+                value: value_schema,
+                value_validator,
+            } => {
+                dump_dict(
+                    registry,
+                    value,
+                    value_schema,
+                    value_validator.as_ref(),
+                    &common.invalid_error,
+                    sink,
+                    key,
+                )?;
+                Ok(true)
+            }
+            Self::Nested {
+                dataclass_index, ..
+            } => {
+                registry
+                    .get(*dataclass_index)
+                    .dump(registry, value, sink, key)?;
+                Ok(true)
+            }
+            Self::Union { variants, .. } => {
+                for variant in variants {
+                    let mut tmp = PyDictSink::new(py);
+                    match variant.dump(registry, value, &mut tmp, None) {
+                        Ok(true) => {
+                            let materialized = tmp.finish();
+                            sink.pyobject(key, materialized.bind(py))?;
+                            return Ok(true);
+                        }
+                        Ok(false) => return Ok(false),
+                        Err(_) => {}
+                    }
+                }
+                Err(SerializationError::Single(
+                    intern!(py, "Value does not match any union variant")
+                        .clone()
+                        .unbind(),
+                ))
+            }
+            _ => {
+                let dumped = self.dump_leaf(value)?;
+                if dumped.is_none(py) {
+                    Ok(false)
+                } else {
+                    sink.leaf(key, dumped.bind(py))?;
+                    Ok(true)
+                }
+            }
+        }
+    }
+
+    fn dump_leaf(&self, value: &Bound<'_, PyAny>) -> Result<Py<PyAny>, SerializationError> {
         let common = self.common();
         match self {
             Self::Str {
@@ -101,49 +291,19 @@ impl FieldContainer {
             Self::BoolLiteral { common, values } => {
                 bool_literal::dump_to_py(value, values, &common.invalid_error)
             }
-            Self::Any { .. } => any::dump_to_py(value),
-            Self::Collection {
-                kind,
-                item,
-                item_validator,
-                min_length,
-                max_length,
-                ..
-            } => collection::dump_to_py(
-                registry,
-                value,
-                *kind,
-                item,
-                item_validator.as_ref(),
-                &common.invalid_error,
-                min_length.as_ref(),
-                max_length.as_ref(),
-            ),
-            Self::Dict {
-                value: value_schema,
-                value_validator,
-                ..
-            } => dict::dump_to_py(
-                registry,
-                value,
-                value_schema,
-                value_validator.as_ref(),
-                &common.invalid_error,
-            ),
-            Self::Nested {
-                dataclass_index, ..
-            } => registry.get(*dataclass_index).dump_to_py(registry, value),
-            Self::Union { variants, .. } => union::dump_to_py(registry, value, variants),
+            _ => unreachable!("dump_leaf called on a non-leaf field"),
         }
     }
 }
 
 impl DataclassContainer {
-    pub fn dump_to_py(
+    pub fn dump<'py, S: DumpSink<'py>>(
         &self,
         registry: &DataclassRegistry,
-        value: &Bound<'_, PyAny>,
-    ) -> Result<Py<PyAny>, SerializationError> {
+        value: &Bound<'py, PyAny>,
+        sink: &mut S,
+        key: Option<&str>,
+    ) -> Result<(), SerializationError> {
         let py = value.py();
 
         if !value.is_instance(self.cls.bind(py)).unwrap_or(false) {
@@ -157,181 +317,175 @@ impl DataclassContainer {
             ));
         }
 
-        let missing_sentinel = crate::utils::get_missing_sentinel(py)
-            .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
+        let missing_sentinel =
+            get_missing_sentinel(py).map_err(|e| SerializationError::simple(py, &e.to_string()))?;
 
-        let result = PyDict::new(py);
-        let mut errors: Option<Bound<'_, PyDict>> = None;
+        sink.open_object(key, |s| {
+            let mut errors: Option<Bound<'_, PyDict>> = None;
 
-        for dc_field in &self.fields {
-            if !dc_field.field_init {
-                continue;
-            }
+            for dc_field in &self.fields {
+                if !dc_field.field_init {
+                    continue;
+                }
 
-            let common = dc_field.field.common();
+                let common = dc_field.field.common();
 
-            let py_value = match dc_field.slot_offset {
-                Some(offset) => {
-                    match unsafe { crate::slots::get_slot_value_direct(py, value, offset) } {
+                let py_value = match dc_field.slot_offset {
+                    Some(offset) => match unsafe { get_slot_value_direct(py, value, offset) } {
                         Some(v) => v,
                         None => value
                             .getattr(dc_field.name_interned.bind(py))
                             .map_err(|e| SerializationError::simple(py, &e.to_string()))?,
-                    }
+                    },
+                    None => value
+                        .getattr(dc_field.name_interned.bind(py))
+                        .map_err(|e| SerializationError::simple(py, &e.to_string()))?,
+                };
+
+                if py_value.is(missing_sentinel.as_any())
+                    || (py_value.is_none() && self.ignore_none)
+                {
+                    continue;
                 }
-                None => value
-                    .getattr(dc_field.name_interned.bind(py))
-                    .map_err(|e| SerializationError::simple(py, &e.to_string()))?,
-            };
 
-            if py_value.is(missing_sentinel.as_any()) || (py_value.is_none() && self.ignore_none) {
-                continue;
-            }
+                if let Some(ref validator) = common.validator
+                    && let Ok(Some(err_list)) = call_validator(py, validator, &py_value)
+                {
+                    let e = pyerrors_to_serialization_error(py, &err_list);
+                    accumulate_error(py, &mut errors, dc_field.name_interned.bind(py), &e);
+                    continue;
+                }
 
-            if let Some(ref validator) = common.validator
-                && let Ok(Some(err_list)) = call_validator(py, validator, &py_value)
-            {
-                let e = pyerrors_to_serialization_error(py, &err_list);
-                accumulate_error(py, &mut errors, dc_field.name_interned.bind(py), &e);
-                continue;
-            }
+                if py_value.is_none() {
+                    s.null(Some(&dc_field.data_key))?;
+                    continue;
+                }
 
-            if py_value.is_none() {
-                result
-                    .set_item(dc_field.data_key_interned.bind(py), py.None())
-                    .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
-            } else {
-                match dc_field.field.dump_to_py(registry, &py_value) {
-                    Ok(dumped) => {
-                        if dumped.is_none(py) && self.ignore_none {
-                            continue;
+                match dc_field
+                    .field
+                    .dump(registry, &py_value, s, Some(&dc_field.data_key))
+                {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        if !self.ignore_none {
+                            s.null(Some(&dc_field.data_key))?;
                         }
-                        result
-                            .set_item(dc_field.data_key_interned.bind(py), dumped)
-                            .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
                     }
                     Err(ref e) => {
                         accumulate_error(py, &mut errors, dc_field.name_interned.bind(py), e);
                     }
                 }
             }
-        }
 
-        if let Some(errors) = errors {
-            return Err(SerializationError::Dict(errors.unbind()));
-        }
-
-        Ok(result.into_any().unbind())
+            if let Some(errors) = errors {
+                return Err(SerializationError::Dict(errors.unbind()));
+            }
+            Ok(())
+        })
     }
 }
 
 impl TypeContainer {
-    pub fn dump_to_py(
+    pub fn dump<'py, S: DumpSink<'py>>(
         &self,
         registry: &DataclassRegistry,
-        value: &Bound<'_, PyAny>,
-    ) -> Result<Py<PyAny>, SerializationError> {
+        value: &Bound<'py, PyAny>,
+        sink: &mut S,
+        key: Option<&str>,
+    ) -> Result<(), SerializationError> {
         let py = value.py();
 
         match self {
-            Self::Dataclass(idx) => registry.get(*idx).dump_to_py(registry, value),
+            Self::Dataclass(idx) => registry.get(*idx).dump(registry, value, sink, key),
             Self::Primitive(p) => {
                 if value.is_none() {
-                    return Ok(py.None());
+                    sink.null(key)
+                } else if p.field.dump(registry, value, sink, key)? {
+                    Ok(())
+                } else {
+                    sink.null(key)
                 }
-                p.field.dump_to_py(registry, value)
             }
             Self::List { item } => {
                 let list = value.cast::<PyList>().map_err(|_| {
                     SerializationError::Single(intern!(py, "Expected a list").clone().unbind())
                 })?;
-                let result = new_presized_list(py, list.len());
-                let mut errors: Option<Bound<'_, PyDict>> = None;
-
-                for (idx, v) in list.iter().enumerate() {
-                    match item.dump_to_py(registry, &v) {
-                        Ok(dumped) => unsafe {
-                            pyo3::ffi::PyList_SET_ITEM(
-                                result.as_ptr(),
-                                idx.cast_signed(),
-                                dumped.into_ptr(),
-                            );
-                        },
-                        Err(ref e) => accumulate_error(py, &mut errors, idx, e),
+                sink.open_array(key, |s| {
+                    let mut errors: Option<Bound<'_, PyDict>> = None;
+                    for (idx, v) in list.iter().enumerate() {
+                        if let Err(ref e) = item.dump(registry, &v, s, None) {
+                            accumulate_error(py, &mut errors, idx, e);
+                        }
                     }
-                }
-
-                if let Some(errors) = errors {
-                    return Err(SerializationError::Dict(errors.unbind()));
-                }
-
-                Ok(result.into_any().unbind())
+                    if let Some(errors) = errors {
+                        return Err(SerializationError::Dict(errors.unbind()));
+                    }
+                    Ok(())
+                })
             }
-            Self::Dict {
-                value: value_container,
-            } => {
+            Self::Dict { value: vc } => {
                 let dict = value.cast::<PyDict>().map_err(|_| {
                     SerializationError::Single(intern!(py, "Expected a dict").clone().unbind())
                 })?;
-                let result = PyDict::new(py);
-                let mut errors: Option<Bound<'_, PyDict>> = None;
-
-                for (k, v) in dict.iter() {
-                    match value_container.dump_to_py(registry, &v) {
-                        Ok(dumped) => {
-                            result
-                                .set_item(k, dumped)
+                sink.open_object(key, |s| {
+                    let mut errors: Option<Bound<'_, PyDict>> = None;
+                    for (k, v) in dict.iter() {
+                        let key_owned;
+                        let key_str = if let Ok(key_obj) = k.cast::<PyString>() {
+                            key_obj
+                                .to_str()
+                                .map_err(|e| SerializationError::simple(py, &e.to_string()))?
+                        } else {
+                            key_owned = k
+                                .str()
                                 .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
-                        }
-                        Err(ref e) => {
-                            let key_str = k.str().map(|s| s.to_string()).unwrap_or_default();
+                            key_owned
+                                .to_str()
+                                .map_err(|e| SerializationError::simple(py, &e.to_string()))?
+                        };
+                        if let Err(ref e) = vc.dump(registry, &v, s, Some(key_str)) {
                             accumulate_error(py, &mut errors, key_str, e);
                         }
                     }
-                }
-
-                if let Some(errors) = errors {
-                    return Err(SerializationError::Dict(errors.unbind()));
-                }
-
-                Ok(result.into_any().unbind())
+                    if let Some(errors) = errors {
+                        return Err(SerializationError::Dict(errors.unbind()));
+                    }
+                    Ok(())
+                })
             }
             Self::Optional { inner } => {
                 if value.is_none() {
-                    Ok(py.None())
+                    sink.null(key)
                 } else {
-                    inner.dump_to_py(registry, value)
+                    inner.dump(registry, value, sink, key)
                 }
             }
-            Self::Set { item } | Self::FrozenSet { item } | Self::Tuple { item } => {
-                let iter = value.try_iter().map_err(|_| {
-                    SerializationError::Single(intern!(py, "Expected an iterable").clone().unbind())
-                })?;
-                let (size_hint, _) = iter.size_hint();
-                let mut items = Vec::with_capacity(size_hint);
-                let mut errors: Option<Bound<'_, PyDict>> = None;
-
-                for (idx, item_result) in iter.enumerate() {
-                    let v =
-                        item_result.map_err(|e| SerializationError::simple(py, &e.to_string()))?;
-                    match item.dump_to_py(registry, &v) {
-                        Ok(dumped) => items.push(dumped),
-                        Err(ref e) => accumulate_error(py, &mut errors, idx, e),
+            Self::Set { item } | Self::FrozenSet { item } | Self::Tuple { item } => sink
+                .open_array(key, |s| {
+                    let iter = value.try_iter().map_err(|_| {
+                        SerializationError::Single(
+                            intern!(py, "Expected an iterable").clone().unbind(),
+                        )
+                    })?;
+                    let mut errors: Option<Bound<'_, PyDict>> = None;
+                    for (idx, item_result) in iter.enumerate() {
+                        let v = item_result
+                            .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
+                        if let Err(ref e) = item.dump(registry, &v, s, None) {
+                            accumulate_error(py, &mut errors, idx, e);
+                        }
                     }
-                }
-
-                if let Some(errors) = errors {
-                    return Err(SerializationError::Dict(errors.unbind()));
-                }
-
-                PyList::new(py, items)
-                    .map(|l| l.into_any().unbind())
-                    .map_err(|e| SerializationError::simple(py, &e.to_string()))
-            }
+                    if let Some(errors) = errors {
+                        return Err(SerializationError::Dict(errors.unbind()));
+                    }
+                    Ok(())
+                }),
             Self::Union { variants } => {
                 for variant in variants {
-                    if let Ok(result) = variant.dump_to_py(registry, value) {
-                        return Ok(result);
+                    let mut tmp = PyDictSink::new(py);
+                    if variant.dump(registry, value, &mut tmp, None).is_ok() {
+                        let materialized = tmp.finish();
+                        return sink.pyobject(key, materialized.bind(py));
                     }
                 }
                 Err(SerializationError::Single(

--- a/src/container_load.rs
+++ b/src/container_load.rs
@@ -12,6 +12,7 @@ use crate::fields::{
     any, bool_literal, bool_type, bytes, collection, date, datetime, decimal, dict, float_type,
     int_enum, int_literal, int_type, str_enum, str_literal, str_type, time, union, uuid,
 };
+use crate::json::parser::Parser;
 use crate::slots::set_slot_value_direct;
 use crate::utils::{
     call_validator, extract_error_args, get_mapping_abc, get_missing_sentinel, get_object_cls,
@@ -866,6 +867,227 @@ impl TypeContainer {
                 }
                 Err(SerializationError::collect_list(py, errors))
             }
+        }
+    }
+}
+
+impl FieldContainer {
+    fn load_value_from_bytes(
+        &self,
+        registry: &DataclassRegistry,
+        parser: &mut Parser<'_>,
+        py: Python<'_>,
+    ) -> Result<Py<PyAny>, SerializationError> {
+        if let Self::Nested {
+            dataclass_index, ..
+        } = self
+        {
+            let dc = registry.get(*dataclass_index);
+            if dc.pre_loads.is_empty() && parser.peek_byte() == Some(b'{') {
+                return dc.load_from_bytes(registry, parser, py);
+            }
+        }
+        let value = parser.parse_to_pyobject(py)?;
+        self.load_from_py(registry, &value)
+    }
+}
+
+impl DataclassContainer {
+    pub fn load_from_bytes(
+        &self,
+        registry: &DataclassRegistry,
+        parser: &mut Parser<'_>,
+        py: Python<'_>,
+    ) -> Result<Py<PyAny>, SerializationError> {
+        if !self.pre_loads.is_empty() || parser.peek_byte() != Some(b'{') {
+            let value = parser.parse_to_pyobject(py)?;
+            return self.load_from_py(registry, &value);
+        }
+        match self.load_strategy {
+            LoadStrategy::DirectSlots => self.load_from_bytes_direct_slots(registry, parser, py),
+            LoadStrategy::DirectDict => {
+                let dict = self.collect_fields_from_bytes(registry, parser, py)?;
+                self.instantiate_via_direct_dict(py, &dict)
+            }
+            LoadStrategy::Kwargs => {
+                let kwargs = self.collect_fields_from_bytes(registry, parser, py)?;
+                self.instantiate_via_kwargs(py, &kwargs)
+            }
+        }
+    }
+
+    fn collect_fields_from_bytes<'py>(
+        &self,
+        registry: &DataclassRegistry,
+        parser: &mut Parser<'_>,
+        py: Python<'py>,
+    ) -> Result<Bound<'py, PyDict>, SerializationError> {
+        let result = PyDict::new(py);
+        let mut seen = SmallBitVec::from_elem(self.fields.len(), false);
+        let mut errors: Option<Bound<'_, PyDict>> = None;
+
+        parser.iter_object(py, |parser, key| {
+            if let Some(&idx) = self.field_lookup.get(key) {
+                let dc_field = &self.fields[idx];
+                let common = dc_field.field.common();
+                seen.set(idx, true);
+                if dc_field.field_init {
+                    match dc_field.field.load_value_from_bytes(registry, parser, py) {
+                        Ok(py_val) => match apply_validate(py, py_val, common.validator.as_ref()) {
+                            Ok(validated) => {
+                                if let Some(ref e) = errors {
+                                    let _ = e.del_item(dc_field.name_interned.bind(py));
+                                }
+                                let _ = result.set_item(dc_field.name_interned.bind(py), validated);
+                            }
+                            Err(ref e) => {
+                                accumulate_error(
+                                    py,
+                                    &mut errors,
+                                    dc_field.name_interned.bind(py),
+                                    e,
+                                );
+                            }
+                        },
+                        Err(ref e) => {
+                            accumulate_error(py, &mut errors, dc_field.name_interned.bind(py), e);
+                        }
+                    }
+                } else {
+                    parser.skip_value(py)?;
+                }
+            } else {
+                parser.skip_value(py)?;
+            }
+            Ok(())
+        })?;
+
+        for (idx, dc_field) in self.fields.iter().enumerate() {
+            let common = dc_field.field.common();
+            if errors
+                .as_ref()
+                .is_some_and(|e| e.contains(dc_field.name_interned.bind(py)).unwrap_or(false))
+            {
+                continue;
+            }
+            if !seen[idx] && dc_field.field_init {
+                match get_default_value(py, common) {
+                    Ok(Some(val)) => {
+                        let _ = result.set_item(dc_field.name_interned.bind(py), val);
+                    }
+                    Ok(None) => {
+                        push_required_error(
+                            py,
+                            &mut errors,
+                            dc_field.name_interned.bind(py),
+                            common,
+                        );
+                    }
+                    Err(ref e) => {
+                        accumulate_error(py, &mut errors, dc_field.name_interned.bind(py), e);
+                    }
+                }
+            }
+        }
+
+        if let Some(errors) = errors {
+            return Err(SerializationError::Dict(errors.unbind()));
+        }
+        Ok(result)
+    }
+
+    fn load_from_bytes_direct_slots(
+        &self,
+        registry: &DataclassRegistry,
+        parser: &mut Parser<'_>,
+        py: Python<'_>,
+    ) -> Result<Py<PyAny>, SerializationError> {
+        let object_type =
+            get_object_cls(py).map_err(|e| SerializationError::simple(py, &e.to_string()))?;
+        let instance = object_type
+            .call_method1(intern!(py, "__new__"), (self.cls.bind(py),))
+            .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
+
+        let mut field_values: Vec<Option<Py<PyAny>>> =
+            (0..self.fields.len()).map(|_| None).collect();
+        let mut errors: Option<Bound<'_, PyDict>> = None;
+
+        parser.iter_object(py, |parser, key| {
+            if let Some(&idx) = self.field_lookup.get(key) {
+                let dc_field = &self.fields[idx];
+                let common = dc_field.field.common();
+                match dc_field.field.load_value_from_bytes(registry, parser, py) {
+                    Ok(py_val) => match apply_validate(py, py_val, common.validator.as_ref()) {
+                        Ok(validated) => {
+                            if let Some(ref e) = errors {
+                                let _ = e.del_item(dc_field.name_interned.bind(py));
+                            }
+                            field_values[idx] = Some(validated);
+                        }
+                        Err(ref e) => {
+                            accumulate_error(py, &mut errors, dc_field.name_interned.bind(py), e);
+                        }
+                    },
+                    Err(ref e) => {
+                        accumulate_error(py, &mut errors, dc_field.name_interned.bind(py), e);
+                    }
+                }
+            } else {
+                parser.skip_value(py)?;
+            }
+            Ok(())
+        })?;
+
+        for (idx, dc_field) in self.fields.iter().enumerate() {
+            let common = dc_field.field.common();
+            if errors
+                .as_ref()
+                .is_some_and(|e| e.contains(dc_field.name_interned.bind(py)).unwrap_or(false))
+            {
+                continue;
+            }
+            let py_value = if let Some(value) = field_values[idx].take() {
+                value
+            } else {
+                match get_default_value(py, common) {
+                    Ok(Some(val)) => val,
+                    Ok(None) => {
+                        push_required_error(
+                            py,
+                            &mut errors,
+                            dc_field.name_interned.bind(py),
+                            common,
+                        );
+                        continue;
+                    }
+                    Err(ref e) => {
+                        accumulate_error(py, &mut errors, dc_field.name_interned.bind(py), e);
+                        continue;
+                    }
+                }
+            };
+            write_field_to_slot_or_attr(py, &instance, dc_field, py_value, &mut errors)?;
+        }
+
+        if let Some(errors) = errors {
+            return Err(SerializationError::Dict(errors.unbind()));
+        }
+        Ok(instance.unbind())
+    }
+}
+
+impl TypeContainer {
+    pub fn load_from_bytes(
+        &self,
+        py: Python<'_>,
+        registry: &DataclassRegistry,
+        parser: &mut Parser<'_>,
+    ) -> Result<Py<PyAny>, SerializationError> {
+        if let Self::Dataclass(idx) = self {
+            registry.get(*idx).load_from_bytes(registry, parser, py)
+        } else {
+            let value = parser.parse_to_pyobject(py)?;
+            self.load_from_py(py, registry, &value)
         }
     }
 }

--- a/src/fields/collection.rs
+++ b/src/fields/collection.rs
@@ -4,7 +4,7 @@ use pyo3::types::{PyDict, PyFrozenSet, PyList, PySet, PyString, PyTuple};
 use crate::container::{DataclassRegistry, FieldContainer};
 use crate::error::{SerializationError, accumulate_error, pyerrors_to_serialization_error};
 use crate::fields::length::{LengthBound, validate_length};
-use crate::utils::{call_validator, new_presized_list};
+use crate::utils::call_validator;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CollectionKind {
@@ -96,62 +96,4 @@ pub fn load_from_py(
             .map(|t| t.into_any().unbind())
             .map_err(|e| SerializationError::simple(py, &e.to_string())),
     }
-}
-
-pub fn dump_to_py(
-    registry: &DataclassRegistry,
-    value: &Bound<'_, PyAny>,
-    kind: CollectionKind,
-    item: &FieldContainer,
-    item_validator: Option<&Py<PyAny>>,
-    invalid_error: &Py<PyString>,
-    min_length: Option<&LengthBound>,
-    max_length: Option<&LengthBound>,
-) -> Result<Py<PyAny>, SerializationError> {
-    let py = value.py();
-
-    if !kind.is_valid_type(value) {
-        return Err(SerializationError::Single(invalid_error.clone_ref(py)));
-    }
-
-    let size = value
-        .len()
-        .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
-
-    validate_length(py, size, min_length, max_length)?;
-
-    let result = new_presized_list(py, size);
-    let mut errors: Option<Bound<'_, PyDict>> = None;
-
-    let iter = value
-        .try_iter()
-        .map_err(|_| SerializationError::Single(invalid_error.clone_ref(py)))?;
-    let mut idx = 0usize;
-
-    for item_result in iter {
-        let item_value = item_result.map_err(|e| SerializationError::simple(py, &e.to_string()))?;
-
-        if let Some(validator) = item_validator
-            && let Ok(Some(err_list)) = call_validator(py, validator, &item_value)
-        {
-            let e = pyerrors_to_serialization_error(py, &err_list);
-            accumulate_error(py, &mut errors, idx, &e);
-            idx += 1;
-            continue;
-        }
-
-        match item.dump_to_py(registry, &item_value) {
-            Ok(dumped) => unsafe {
-                pyo3::ffi::PyList_SET_ITEM(result.as_ptr(), idx.cast_signed(), dumped.into_ptr());
-            },
-            Err(ref e) => accumulate_error(py, &mut errors, idx, e),
-        }
-        idx += 1;
-    }
-
-    if let Some(errors) = errors {
-        return Err(SerializationError::Dict(errors.unbind()));
-    }
-
-    Ok(result.into_any().unbind())
 }

--- a/src/fields/dict.rs
+++ b/src/fields/dict.rs
@@ -1,4 +1,3 @@
-use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 
@@ -70,64 +69,6 @@ pub fn load_from_py(
                 .get_item(&k)
                 .map_err(|_| SerializationError::Single(invalid_error.clone_ref(py)))?;
             handle(k, v);
-        }
-    }
-
-    if let Some(errors) = errors {
-        return Err(SerializationError::Dict(errors.unbind()));
-    }
-
-    Ok(result.into_any().unbind())
-}
-
-pub fn dump_to_py(
-    registry: &DataclassRegistry,
-    value: &Bound<'_, PyAny>,
-    value_schema: &FieldContainer,
-    value_validator: Option<&Py<PyAny>>,
-    invalid_error: &Py<PyString>,
-) -> Result<Py<PyAny>, SerializationError> {
-    let py = value.py();
-
-    let dict = value
-        .cast::<PyDict>()
-        .map_err(|_| SerializationError::Single(invalid_error.clone_ref(py)))?;
-
-    let result = PyDict::new(py);
-    let mut errors: Option<Bound<'_, PyDict>> = None;
-
-    for (k, v) in dict.iter() {
-        let key_str = k
-            .cast::<PyString>()
-            .map_err(|_| {
-                SerializationError::Single(
-                    intern!(py, "Dict key must be a string").clone().unbind(),
-                )
-            })?
-            .to_str()
-            .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
-
-        if let Some(validator) = value_validator
-            && let Ok(Some(err_list)) = call_validator(py, validator, &v)
-        {
-            let e = pyerrors_to_serialization_error(py, &err_list);
-            accumulate_error(py, &mut errors, key_str, &e);
-            continue;
-        }
-
-        match value_schema.dump_to_py(registry, &v) {
-            Ok(dumped) => {
-                result
-                    .set_item(k, dumped)
-                    .map_err(|e| SerializationError::simple(py, &e.to_string()))?;
-            }
-            Err(e) => {
-                let nested_dict = PyDict::new(py);
-                let _ =
-                    nested_dict.set_item("value", e.to_py_value(py).unwrap_or_else(|_| py.None()));
-                let wrapped = SerializationError::Dict(nested_dict.unbind());
-                accumulate_error(py, &mut errors, key_str, &wrapped);
-            }
         }
     }
 

--- a/src/fields/union.rs
+++ b/src/fields/union.rs
@@ -1,4 +1,3 @@
-use pyo3::intern;
 use pyo3::prelude::*;
 
 use crate::container::{DataclassRegistry, FieldContainer};
@@ -18,23 +17,4 @@ pub fn load_from_py(
         }
     }
     Err(SerializationError::collect_list(py, errors))
-}
-
-pub fn dump_to_py(
-    registry: &DataclassRegistry,
-    value: &Bound<'_, PyAny>,
-    variants: &[FieldContainer],
-) -> Result<Py<PyAny>, SerializationError> {
-    let py = value.py();
-    for variant in variants {
-        if let Ok(result) = variant.dump_to_py(registry, value) {
-            return Ok(result);
-        }
-    }
-
-    Err(SerializationError::Single(
-        intern!(py, "Value does not match any union variant")
-            .clone()
-            .unbind(),
-    ))
 }

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -1,0 +1,3 @@
+pub mod parser;
+pub mod sink;
+pub mod writer;

--- a/src/json/parser.rs
+++ b/src/json/parser.rs
@@ -1,0 +1,389 @@
+use pyo3::conversion::IntoPyObjectExt;
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyDict, PyFloat, PyList, PyString};
+
+use crate::error::SerializationError;
+
+const MAX_DEPTH: usize = 256;
+
+fn push_char(out: &mut Vec<u8>, c: char) {
+    let mut b = [0u8; 4];
+    out.extend_from_slice(c.encode_utf8(&mut b).as_bytes());
+}
+
+pub struct Parser<'a> {
+    d: &'a [u8],
+    i: usize,
+    depth: usize,
+}
+
+impl<'a> Parser<'a> {
+    pub const fn new(d: &'a [u8]) -> Self {
+        Self { d, i: 0, depth: 0 }
+    }
+
+    fn err(py: Python<'_>, msg: &str) -> SerializationError {
+        SerializationError::simple(py, &format!("Invalid JSON: {msg}"))
+    }
+
+    pub fn skip_ws(&mut self) {
+        while self.i < self.d.len() && matches!(self.d[self.i], b' ' | b'\t' | b'\n' | b'\r') {
+            self.i += 1;
+        }
+    }
+
+    fn peek(&self, py: Python<'_>) -> Result<u8, SerializationError> {
+        self.d
+            .get(self.i)
+            .copied()
+            .ok_or_else(|| Self::err(py, "unexpected end of input"))
+    }
+
+    pub fn peek_byte(&mut self) -> Option<u8> {
+        self.skip_ws();
+        self.d.get(self.i).copied()
+    }
+
+    pub fn at_end(&mut self) -> bool {
+        self.skip_ws();
+        self.i >= self.d.len()
+    }
+
+    pub const fn bump(&mut self) {
+        self.i += 1;
+    }
+
+    pub fn expect(&mut self, py: Python<'_>, b: u8) -> Result<(), SerializationError> {
+        self.skip_ws();
+        if self.peek(py)? == b {
+            self.i += 1;
+            Ok(())
+        } else {
+            Err(Self::err(py, "unexpected character"))
+        }
+    }
+
+    fn lit(&mut self, py: Python<'_>, s: &str) -> Result<(), SerializationError> {
+        for &b in s.as_bytes() {
+            if self.peek(py)? != b {
+                return Err(Self::err(py, "invalid literal"));
+            }
+            self.i += 1;
+        }
+        Ok(())
+    }
+
+    fn hex4(&mut self, py: Python<'_>) -> Result<u32, SerializationError> {
+        let mut v = 0u32;
+        for _ in 0..4 {
+            let c = self.peek(py)?;
+            self.i += 1;
+            let d = match c {
+                b'0'..=b'9' => u32::from(c - b'0'),
+                b'a'..=b'f' => u32::from(c - b'a' + 10),
+                b'A'..=b'F' => u32::from(c - b'A' + 10),
+                _ => return Err(Self::err(py, "invalid \\u escape")),
+            };
+            v = v * 16 + d;
+        }
+        Ok(v)
+    }
+
+    pub fn parse_string_raw(&mut self, py: Python<'_>) -> Result<String, SerializationError> {
+        self.skip_ws();
+        if self.peek(py)? != b'"' {
+            return Err(Self::err(py, "expected string"));
+        }
+        self.i += 1;
+        let mut out: Vec<u8> = Vec::new();
+        loop {
+            let c = self.peek(py)?;
+            self.i += 1;
+            match c {
+                b'"' => break,
+                b'\\' => {
+                    let e = self.peek(py)?;
+                    self.i += 1;
+                    match e {
+                        b'"' => out.push(b'"'),
+                        b'\\' => out.push(b'\\'),
+                        b'/' => out.push(b'/'),
+                        b'b' => out.push(0x08),
+                        b'f' => out.push(0x0c),
+                        b'n' => out.push(b'\n'),
+                        b'r' => out.push(b'\r'),
+                        b't' => out.push(b'\t'),
+                        b'u' => {
+                            let cp = self.hex4(py)?;
+                            if (0xD800..=0xDBFF).contains(&cp) {
+                                if self.peek(py)? != b'\\' {
+                                    return Err(Self::err(py, "expected low surrogate"));
+                                }
+                                self.i += 1;
+                                if self.peek(py)? != b'u' {
+                                    return Err(Self::err(py, "expected low surrogate"));
+                                }
+                                self.i += 1;
+                                let lo = self.hex4(py)?;
+                                if !(0xDC00..=0xDFFF).contains(&lo) {
+                                    return Err(Self::err(py, "invalid low surrogate"));
+                                }
+                                let combined = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                                push_char(
+                                    &mut out,
+                                    char::from_u32(combined)
+                                        .ok_or_else(|| Self::err(py, "invalid code point"))?,
+                                );
+                            } else if (0xDC00..=0xDFFF).contains(&cp) {
+                                return Err(Self::err(py, "unexpected low surrogate"));
+                            } else {
+                                push_char(
+                                    &mut out,
+                                    char::from_u32(cp)
+                                        .ok_or_else(|| Self::err(py, "invalid code point"))?,
+                                );
+                            }
+                        }
+                        _ => return Err(Self::err(py, "invalid escape")),
+                    }
+                }
+                0x00..=0x1f => return Err(Self::err(py, "control character in string")),
+                _ => out.push(c),
+            }
+        }
+        String::from_utf8(out).map_err(|_| Self::err(py, "invalid utf-8"))
+    }
+
+    fn parse_number_slice(
+        &mut self,
+        py: Python<'_>,
+    ) -> Result<(&'a str, bool), SerializationError> {
+        let start = self.i;
+        let mut is_float = false;
+        if self.peek(py)? == b'-' {
+            self.i += 1;
+        }
+        match self.peek(py)? {
+            b'0' => {
+                self.i += 1;
+                if self.i < self.d.len() && self.d[self.i].is_ascii_digit() {
+                    return Err(Self::err(py, "leading zero"));
+                }
+            }
+            b'1'..=b'9' => {
+                while self.i < self.d.len() && self.d[self.i].is_ascii_digit() {
+                    self.i += 1;
+                }
+            }
+            _ => return Err(Self::err(py, "invalid number")),
+        }
+        if self.i < self.d.len() && self.d[self.i] == b'.' {
+            is_float = true;
+            self.i += 1;
+            if !(self.i < self.d.len() && self.d[self.i].is_ascii_digit()) {
+                return Err(Self::err(py, "invalid number"));
+            }
+            while self.i < self.d.len() && self.d[self.i].is_ascii_digit() {
+                self.i += 1;
+            }
+        }
+        if self.i < self.d.len() && (self.d[self.i] == b'e' || self.d[self.i] == b'E') {
+            is_float = true;
+            self.i += 1;
+            if self.i < self.d.len() && (self.d[self.i] == b'+' || self.d[self.i] == b'-') {
+                self.i += 1;
+            }
+            if !(self.i < self.d.len() && self.d[self.i].is_ascii_digit()) {
+                return Err(Self::err(py, "invalid number"));
+            }
+            while self.i < self.d.len() && self.d[self.i].is_ascii_digit() {
+                self.i += 1;
+            }
+        }
+        let s = std::str::from_utf8(&self.d[start..self.i])
+            .map_err(|_| Self::err(py, "invalid number"))?;
+        Ok((s, is_float))
+    }
+
+    fn build_number<'py>(
+        &mut self,
+        py: Python<'py>,
+    ) -> Result<Bound<'py, PyAny>, SerializationError> {
+        let (slice, is_float) = self.parse_number_slice(py)?;
+        if is_float {
+            let f: f64 = slice.parse().map_err(|_| Self::err(py, "invalid number"))?;
+            return Ok(PyFloat::new(py, f).into_any());
+        }
+        if let Ok(i) = slice.parse::<i64>() {
+            return i
+                .into_py_any(py)
+                .map(|p| p.into_bound(py))
+                .map_err(|e| SerializationError::from_pyerr(py, &e));
+        }
+        py.import("builtins")
+            .and_then(|b| b.getattr("int"))
+            .and_then(|int| int.call1((slice,)))
+            .map_err(|e| SerializationError::from_pyerr(py, &e))
+    }
+
+    fn enter(&mut self, py: Python<'_>) -> Result<(), SerializationError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            return Err(Self::err(py, "nesting too deep"));
+        }
+        Ok(())
+    }
+
+    const fn leave(&mut self) {
+        self.depth -= 1;
+    }
+
+    /// Drive a JSON object: handle `{`, `}`, commas, the empty case, nesting depth, and syntax
+    /// errors here once; `on_member` is called with the parser positioned at each member's value
+    /// (after `key` and `:`).
+    pub fn iter_object<F>(
+        &mut self,
+        py: Python<'_>,
+        mut on_member: F,
+    ) -> Result<(), SerializationError>
+    where
+        F: FnMut(&mut Self, &str) -> Result<(), SerializationError>,
+    {
+        self.enter(py)?;
+        self.expect(py, b'{')?;
+        if self.peek_byte() == Some(b'}') {
+            self.bump();
+        } else {
+            loop {
+                let key = self.parse_string_raw(py)?;
+                self.expect(py, b':')?;
+                on_member(self, &key)?;
+                match self.peek_byte() {
+                    Some(b',') => self.bump(),
+                    Some(b'}') => {
+                        self.bump();
+                        break;
+                    }
+                    _ => return Err(Self::err(py, "expected ',' or '}'")),
+                }
+            }
+        }
+        self.leave();
+        Ok(())
+    }
+
+    /// Drive a JSON array: handle `[`, `]`, commas, the empty case, nesting depth, and syntax
+    /// errors here once; `on_item` is called with the parser positioned at each item.
+    pub fn iter_array<F>(
+        &mut self,
+        py: Python<'_>,
+        mut on_item: F,
+    ) -> Result<(), SerializationError>
+    where
+        F: FnMut(&mut Self) -> Result<(), SerializationError>,
+    {
+        self.enter(py)?;
+        self.expect(py, b'[')?;
+        if self.peek_byte() == Some(b']') {
+            self.bump();
+        } else {
+            loop {
+                on_item(self)?;
+                match self.peek_byte() {
+                    Some(b',') => self.bump(),
+                    Some(b']') => {
+                        self.bump();
+                        break;
+                    }
+                    _ => return Err(Self::err(py, "expected ',' or ']'")),
+                }
+            }
+        }
+        self.leave();
+        Ok(())
+    }
+
+    /// Parse the next JSON value into the Python object that `json.loads` would build.
+    pub fn parse_to_pyobject<'py>(
+        &mut self,
+        py: Python<'py>,
+    ) -> Result<Bound<'py, PyAny>, SerializationError> {
+        self.skip_ws();
+        match self.peek(py)? {
+            b'"' => {
+                let s = self.parse_string_raw(py)?;
+                Ok(PyString::new(py, &s).into_any())
+            }
+            b'{' => {
+                let dict = PyDict::new(py);
+                self.iter_object(py, |s, key| {
+                    let value = s.parse_to_pyobject(py)?;
+                    dict.set_item(PyString::new(py, key), value)
+                        .map_err(|e| SerializationError::from_pyerr(py, &e))
+                })?;
+                Ok(dict.into_any())
+            }
+            b'[' => {
+                let list = PyList::empty(py);
+                self.iter_array(py, |s| {
+                    let value = s.parse_to_pyobject(py)?;
+                    list.append(value)
+                        .map_err(|e| SerializationError::from_pyerr(py, &e))
+                })?;
+                Ok(list.into_any())
+            }
+            b't' => {
+                self.lit(py, "true")?;
+                Ok(PyBool::new(py, true).to_owned().into_any())
+            }
+            b'f' => {
+                self.lit(py, "false")?;
+                Ok(PyBool::new(py, false).to_owned().into_any())
+            }
+            b'n' => {
+                self.lit(py, "null")?;
+                Ok(py.None().into_bound(py))
+            }
+            b'N' => {
+                self.lit(py, "NaN")?;
+                Ok(PyFloat::new(py, f64::NAN).into_any())
+            }
+            b'I' => {
+                self.lit(py, "Infinity")?;
+                Ok(PyFloat::new(py, f64::INFINITY).into_any())
+            }
+            b'-' if self.d.get(self.i + 1) == Some(&b'I') => {
+                self.i += 1;
+                self.lit(py, "Infinity")?;
+                Ok(PyFloat::new(py, f64::NEG_INFINITY).into_any())
+            }
+            b'-' | b'0'..=b'9' => self.build_number(py),
+            _ => Err(Self::err(py, "unexpected token")),
+        }
+    }
+
+    pub fn skip_value(&mut self, py: Python<'_>) -> Result<(), SerializationError> {
+        self.skip_ws();
+        match self.peek(py)? {
+            b'"' => {
+                self.parse_string_raw(py)?;
+            }
+            b'{' => self.iter_object(py, |s, _key| s.skip_value(py))?,
+            b'[' => self.iter_array(py, |s| s.skip_value(py))?,
+            b't' => self.lit(py, "true")?,
+            b'f' => self.lit(py, "false")?,
+            b'n' => self.lit(py, "null")?,
+            b'N' => self.lit(py, "NaN")?,
+            b'I' => self.lit(py, "Infinity")?,
+            b'-' if self.d.get(self.i + 1) == Some(&b'I') => {
+                self.i += 1;
+                self.lit(py, "Infinity")?;
+            }
+            b'-' | b'0'..=b'9' => {
+                self.parse_number_slice(py)?;
+            }
+            _ => return Err(Self::err(py, "unexpected token")),
+        }
+        Ok(())
+    }
+}

--- a/src/json/sink.rs
+++ b/src/json/sink.rs
@@ -124,7 +124,6 @@ impl<'py> DumpSink<'py> for PyDictSink<'py> {
 
 pub struct JsonWriterSink {
     w: JsonWriter,
-    first: bool,
 }
 
 impl Default for JsonWriterSink {
@@ -137,18 +136,6 @@ impl JsonWriterSink {
     pub fn new() -> Self {
         Self {
             w: JsonWriter::new(),
-            first: true,
-        }
-    }
-
-    fn pre(&mut self, key: Option<&str>) {
-        if !self.first {
-            self.w.push(b',');
-        }
-        self.first = false;
-        if let Some(k) = key {
-            self.w.write_str(k);
-            self.w.push(b':');
         }
     }
 }
@@ -157,13 +144,11 @@ impl<'py> DumpSink<'py> for JsonWriterSink {
     type Out = Vec<u8>;
 
     fn leaf(&mut self, key: Option<&str>, v: &Bound<'py, PyAny>) -> Result<(), SerializationError> {
-        self.pre(key);
-        write_leaf(&mut self.w, v.py(), v)
+        write_leaf(&mut self.w, key, v)
     }
 
     fn null(&mut self, key: Option<&str>) -> Result<(), SerializationError> {
-        self.pre(key);
-        self.w.write_null();
+        self.w.value_null(key);
         Ok(())
     }
 
@@ -172,28 +157,21 @@ impl<'py> DumpSink<'py> for JsonWriterSink {
         key: Option<&str>,
         v: &Bound<'py, PyAny>,
     ) -> Result<(), SerializationError> {
-        self.pre(key);
-        write_pyobject(&mut self.w, v)
+        write_pyobject(&mut self.w, key, v)
     }
 
     fn open_object<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
     where
         F: FnOnce(&mut Self) -> Result<(), SerializationError>,
     {
-        let mark = self.w.len();
-        let had_first = self.first;
-        self.pre(key);
-        self.w.push(b'{');
-        let parent_first = std::mem::replace(&mut self.first, true);
+        let frame = self.w.begin_object(key);
         match body(self) {
             Ok(()) => {
-                self.w.push(b'}');
-                self.first = parent_first;
+                self.w.end_object();
                 Ok(())
             }
             Err(e) => {
-                self.w.truncate(mark);
-                self.first = had_first;
+                self.w.rollback(frame);
                 Err(e)
             }
         }
@@ -203,20 +181,14 @@ impl<'py> DumpSink<'py> for JsonWriterSink {
     where
         F: FnOnce(&mut Self) -> Result<(), SerializationError>,
     {
-        let mark = self.w.len();
-        let had_first = self.first;
-        self.pre(key);
-        self.w.push(b'[');
-        let parent_first = std::mem::replace(&mut self.first, true);
+        let frame = self.w.begin_array(key);
         match body(self) {
             Ok(()) => {
-                self.w.push(b']');
-                self.first = parent_first;
+                self.w.end_array();
                 Ok(())
             }
             Err(e) => {
-                self.w.truncate(mark);
-                self.first = had_first;
+                self.w.rollback(frame);
                 Err(e)
             }
         }
@@ -235,42 +207,69 @@ pub fn wrap_value_error(py: Python<'_>, e: &SerializationError) -> Serialization
 
 fn write_leaf(
     w: &mut JsonWriter,
-    py: Python<'_>,
+    key: Option<&str>,
     v: &Bound<'_, PyAny>,
 ) -> Result<(), SerializationError> {
+    let py = v.py();
     if v.is_none() {
-        w.write_null();
+        w.value_null(key);
     } else if v.is_instance_of::<PyBool>() {
-        w.write_bool(v.extract::<bool>().unwrap_or(false));
+        w.value_bool(key, v.extract::<bool>().unwrap_or(false));
     } else if let Ok(s) = v.cast::<PyString>() {
-        w.write_str_value(s)
+        let s = s
+            .to_str()
             .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+        w.value_str(key, s);
     } else if v.is_instance_of::<PyInt>() {
-        w.write_pyint(v)
-            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+        write_pyint(w, key, v)?;
     } else if v.is_instance_of::<PyFloat>() {
         let f = v
             .extract::<f64>()
             .map_err(|e| SerializationError::from_pyerr(py, &e))?;
-        w.write_f64(f);
+        w.value_f64(key, f);
     } else {
         return Err(SerializationError::simple(py, ANY_ERROR));
     }
     Ok(())
 }
 
-fn write_pyobject(w: &mut JsonWriter, v: &Bound<'_, PyAny>) -> Result<(), SerializationError> {
+fn write_pyint(
+    w: &mut JsonWriter,
+    key: Option<&str>,
+    v: &Bound<'_, PyAny>,
+) -> Result<(), SerializationError> {
+    let py = v.py();
+    if let Ok(i) = v.extract::<i64>() {
+        w.value_i64(key, i);
+    } else {
+        let s = v
+            .str()
+            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+        let s = s
+            .to_str()
+            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+        w.value_number_str(key, s);
+    }
+    Ok(())
+}
+
+fn write_pyobject(
+    w: &mut JsonWriter,
+    key: Option<&str>,
+    v: &Bound<'_, PyAny>,
+) -> Result<(), SerializationError> {
     let py = v.py();
     if v.is_none() {
-        w.write_null();
+        w.value_null(key);
     } else if v.is_instance_of::<PyBool>() {
-        w.write_bool(v.extract::<bool>().unwrap_or(false));
+        w.value_bool(key, v.extract::<bool>().unwrap_or(false));
     } else if v.is_instance_of::<PyInt>() {
-        w.write_pyint(v)
-            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+        write_pyint(w, key, v)?;
     } else if let Ok(s) = v.cast::<PyString>() {
-        w.write_str_value(s)
+        let s = s
+            .to_str()
             .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+        w.value_str(key, s);
     } else if v.is_instance_of::<PyFloat>() {
         let f = v
             .extract::<f64>()
@@ -280,35 +279,27 @@ fn write_pyobject(w: &mut JsonWriter, v: &Bound<'_, PyAny>) -> Result<(), Serial
                 intern!(py, ANY_ERROR).clone().unbind(),
             ));
         }
-        w.write_f64(f);
+        w.value_f64(key, f);
     } else if let Ok(list) = v.cast::<PyList>() {
-        w.push(b'[');
-        let mut first = true;
-        for item in list.iter() {
-            if !first {
-                w.push(b',');
+        w.array(key, |w| {
+            for item in list.iter() {
+                write_pyobject(w, None, &item)?;
             }
-            first = false;
-            write_pyobject(w, &item)?;
-        }
-        w.push(b']');
+            Ok(())
+        })?;
     } else if let Ok(dict) = v.cast::<PyDict>() {
-        w.push(b'{');
-        let mut first = true;
-        for (k, val) in dict.iter() {
-            let ks = k
-                .cast::<PyString>()
-                .map_err(|_| SerializationError::Single(intern!(py, ANY_ERROR).clone().unbind()))?;
-            if !first {
-                w.push(b',');
+        w.object(key, |w| {
+            for (k, val) in dict.iter() {
+                let ks = k.cast::<PyString>().map_err(|_| {
+                    SerializationError::Single(intern!(py, ANY_ERROR).clone().unbind())
+                })?;
+                let ks = ks
+                    .to_str()
+                    .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+                write_pyobject(w, Some(ks), &val)?;
             }
-            first = false;
-            w.write_str_value(ks)
-                .map_err(|e| SerializationError::from_pyerr(py, &e))?;
-            w.push(b':');
-            write_pyobject(w, &val)?;
-        }
-        w.push(b'}');
+            Ok(())
+        })?;
     } else {
         return Err(SerializationError::Single(
             intern!(py, ANY_ERROR).clone().unbind(),

--- a/src/json/sink.rs
+++ b/src/json/sink.rs
@@ -1,0 +1,318 @@
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
+
+use crate::error::SerializationError;
+use crate::json::writer::JsonWriter;
+
+const ANY_ERROR: &str = "Not a valid JSON-serializable value.";
+
+/// A sink for a JSON value tree. The traversal drives the sink with leaf/null/object/array
+/// events; nesting rides the Rust call stack via `open_object`/`open_array` closures (no heap
+/// stack), which is what keeps the `PyDictSink` path at parity with a hand-written builder.
+///
+/// `key` is `Some(_)` for object members and `None` for array items and the single root value.
+pub trait DumpSink<'py> {
+    type Out;
+
+    fn leaf(&mut self, key: Option<&str>, v: &Bound<'py, PyAny>) -> Result<(), SerializationError>;
+    fn null(&mut self, key: Option<&str>) -> Result<(), SerializationError>;
+    fn pyobject(
+        &mut self,
+        key: Option<&str>,
+        v: &Bound<'py, PyAny>,
+    ) -> Result<(), SerializationError>;
+    fn open_object<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializationError>;
+    fn open_array<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializationError>;
+    fn finish(self) -> Self::Out;
+}
+
+enum Cur<'py> {
+    Root,
+    Dict(Bound<'py, PyDict>),
+    List(Bound<'py, PyList>),
+}
+
+pub struct PyDictSink<'py> {
+    py: Python<'py>,
+    current: Cur<'py>,
+    root: Option<Py<PyAny>>,
+}
+
+impl<'py> PyDictSink<'py> {
+    pub const fn new(py: Python<'py>) -> Self {
+        Self {
+            py,
+            current: Cur::Root,
+            root: None,
+        }
+    }
+
+    fn attach(
+        &mut self,
+        key: Option<&str>,
+        v: &Bound<'py, PyAny>,
+    ) -> Result<(), SerializationError> {
+        match (&self.current, key) {
+            (Cur::Dict(d), Some(k)) => d
+                .set_item(k, v)
+                .map_err(|e| SerializationError::simple(self.py, &e.to_string())),
+            (Cur::List(l), None) => l
+                .append(v)
+                .map_err(|e| SerializationError::simple(self.py, &e.to_string())),
+            (Cur::Root, None) => {
+                self.root = Some(v.clone().unbind());
+                Ok(())
+            }
+            _ => Err(SerializationError::simple(self.py, "sink misuse")),
+        }
+    }
+}
+
+impl<'py> DumpSink<'py> for PyDictSink<'py> {
+    type Out = Py<PyAny>;
+
+    fn leaf(&mut self, key: Option<&str>, v: &Bound<'py, PyAny>) -> Result<(), SerializationError> {
+        self.attach(key, v)
+    }
+
+    fn null(&mut self, key: Option<&str>) -> Result<(), SerializationError> {
+        let none = self.py.None().into_bound(self.py);
+        self.attach(key, &none)
+    }
+
+    fn pyobject(
+        &mut self,
+        key: Option<&str>,
+        v: &Bound<'py, PyAny>,
+    ) -> Result<(), SerializationError> {
+        self.attach(key, v)
+    }
+
+    fn open_object<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializationError>,
+    {
+        let child = PyDict::new(self.py);
+        let parent = std::mem::replace(&mut self.current, Cur::Dict(child.clone()));
+        let r = body(self);
+        self.current = parent;
+        r?;
+        self.attach(key, &child.into_any())
+    }
+
+    fn open_array<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializationError>,
+    {
+        let child = PyList::empty(self.py);
+        let parent = std::mem::replace(&mut self.current, Cur::List(child.clone()));
+        let r = body(self);
+        self.current = parent;
+        r?;
+        self.attach(key, &child.into_any())
+    }
+
+    fn finish(self) -> Self::Out {
+        self.root.unwrap_or_else(|| self.py.None())
+    }
+}
+
+pub struct JsonWriterSink {
+    w: JsonWriter,
+    first: bool,
+}
+
+impl Default for JsonWriterSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JsonWriterSink {
+    pub fn new() -> Self {
+        Self {
+            w: JsonWriter::new(),
+            first: true,
+        }
+    }
+
+    fn pre(&mut self, key: Option<&str>) {
+        if !self.first {
+            self.w.push(b',');
+        }
+        self.first = false;
+        if let Some(k) = key {
+            self.w.write_str(k);
+            self.w.push(b':');
+        }
+    }
+}
+
+impl<'py> DumpSink<'py> for JsonWriterSink {
+    type Out = Vec<u8>;
+
+    fn leaf(&mut self, key: Option<&str>, v: &Bound<'py, PyAny>) -> Result<(), SerializationError> {
+        self.pre(key);
+        write_leaf(&mut self.w, v.py(), v)
+    }
+
+    fn null(&mut self, key: Option<&str>) -> Result<(), SerializationError> {
+        self.pre(key);
+        self.w.write_null();
+        Ok(())
+    }
+
+    fn pyobject(
+        &mut self,
+        key: Option<&str>,
+        v: &Bound<'py, PyAny>,
+    ) -> Result<(), SerializationError> {
+        self.pre(key);
+        write_pyobject(&mut self.w, v)
+    }
+
+    fn open_object<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializationError>,
+    {
+        let mark = self.w.len();
+        let had_first = self.first;
+        self.pre(key);
+        self.w.push(b'{');
+        let parent_first = std::mem::replace(&mut self.first, true);
+        match body(self) {
+            Ok(()) => {
+                self.w.push(b'}');
+                self.first = parent_first;
+                Ok(())
+            }
+            Err(e) => {
+                self.w.truncate(mark);
+                self.first = had_first;
+                Err(e)
+            }
+        }
+    }
+
+    fn open_array<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializationError>,
+    {
+        let mark = self.w.len();
+        let had_first = self.first;
+        self.pre(key);
+        self.w.push(b'[');
+        let parent_first = std::mem::replace(&mut self.first, true);
+        match body(self) {
+            Ok(()) => {
+                self.w.push(b']');
+                self.first = parent_first;
+                Ok(())
+            }
+            Err(e) => {
+                self.w.truncate(mark);
+                self.first = had_first;
+                Err(e)
+            }
+        }
+    }
+
+    fn finish(self) -> Self::Out {
+        self.w.into_bytes()
+    }
+}
+
+pub fn wrap_value_error(py: Python<'_>, e: &SerializationError) -> SerializationError {
+    let nested = PyDict::new(py);
+    let _ = nested.set_item("value", e.to_py_value(py).unwrap_or_else(|_| py.None()));
+    SerializationError::Dict(nested.unbind())
+}
+
+fn write_leaf(
+    w: &mut JsonWriter,
+    py: Python<'_>,
+    v: &Bound<'_, PyAny>,
+) -> Result<(), SerializationError> {
+    if v.is_none() {
+        w.write_null();
+    } else if v.is_instance_of::<PyBool>() {
+        w.write_bool(v.extract::<bool>().unwrap_or(false));
+    } else if let Ok(s) = v.cast::<PyString>() {
+        w.write_str_value(s)
+            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+    } else if v.is_instance_of::<PyInt>() {
+        w.write_pyint(v)
+            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+    } else if v.is_instance_of::<PyFloat>() {
+        let f = v
+            .extract::<f64>()
+            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+        w.write_f64(f);
+    } else {
+        return Err(SerializationError::simple(py, ANY_ERROR));
+    }
+    Ok(())
+}
+
+fn write_pyobject(w: &mut JsonWriter, v: &Bound<'_, PyAny>) -> Result<(), SerializationError> {
+    let py = v.py();
+    if v.is_none() {
+        w.write_null();
+    } else if v.is_instance_of::<PyBool>() {
+        w.write_bool(v.extract::<bool>().unwrap_or(false));
+    } else if v.is_instance_of::<PyInt>() {
+        w.write_pyint(v)
+            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+    } else if let Ok(s) = v.cast::<PyString>() {
+        w.write_str_value(s)
+            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+    } else if v.is_instance_of::<PyFloat>() {
+        let f = v
+            .extract::<f64>()
+            .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+        if !f.is_finite() {
+            return Err(SerializationError::Single(
+                intern!(py, ANY_ERROR).clone().unbind(),
+            ));
+        }
+        w.write_f64(f);
+    } else if let Ok(list) = v.cast::<PyList>() {
+        w.push(b'[');
+        let mut first = true;
+        for item in list.iter() {
+            if !first {
+                w.push(b',');
+            }
+            first = false;
+            write_pyobject(w, &item)?;
+        }
+        w.push(b']');
+    } else if let Ok(dict) = v.cast::<PyDict>() {
+        w.push(b'{');
+        let mut first = true;
+        for (k, val) in dict.iter() {
+            let ks = k
+                .cast::<PyString>()
+                .map_err(|_| SerializationError::Single(intern!(py, ANY_ERROR).clone().unbind()))?;
+            if !first {
+                w.push(b',');
+            }
+            first = false;
+            w.write_str_value(ks)
+                .map_err(|e| SerializationError::from_pyerr(py, &e))?;
+            w.push(b':');
+            write_pyobject(w, &val)?;
+        }
+        w.push(b'}');
+    } else {
+        return Err(SerializationError::Single(
+            intern!(py, ANY_ERROR).clone().unbind(),
+        ));
+    }
+    Ok(())
+}

--- a/src/json/writer.rs
+++ b/src/json/writer.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use crate::error::SerializationError;
 
 const HEX: &[u8; 16] = b"0123456789abcdef";
@@ -141,22 +143,7 @@ impl JsonWriter {
     }
 
     fn fmt_i64(&mut self, i: i64) {
-        const DIGITS: &[u8; 10] = b"0123456789";
-        let mut tmp = [0u8; 20];
-        let mut idx = tmp.len();
-        let mut m = i.unsigned_abs();
-        loop {
-            idx -= 1;
-            tmp[idx] = DIGITS[usize::try_from(m % 10).unwrap_or(0)];
-            m /= 10;
-            if m == 0 {
-                break;
-            }
-        }
-        if i < 0 {
-            self.buf.push(b'-');
-        }
-        self.buf.extend_from_slice(&tmp[idx..]);
+        write!(self.buf, "{i}").expect("writing to Vec<u8> must not fail");
     }
 
     fn fmt_f64(&mut self, f: f64) {

--- a/src/json/writer.rs
+++ b/src/json/writer.rs
@@ -1,0 +1,144 @@
+use pyo3::prelude::*;
+use pyo3::types::PyString;
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+pub struct JsonWriter {
+    buf: Vec<u8>,
+}
+
+impl Default for JsonWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JsonWriter {
+    pub fn new() -> Self {
+        Self {
+            buf: Vec::with_capacity(256),
+        }
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.buf
+    }
+
+    pub const fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    pub fn truncate(&mut self, n: usize) {
+        self.buf.truncate(n);
+    }
+
+    pub fn push(&mut self, b: u8) {
+        self.buf.push(b);
+    }
+
+    pub fn write_null(&mut self) {
+        self.buf.extend_from_slice(b"null");
+    }
+
+    pub fn write_bool(&mut self, b: bool) {
+        self.buf
+            .extend_from_slice(if b { b"true" } else { b"false" });
+    }
+
+    pub fn write_i64(&mut self, i: i64) {
+        const DIGITS: &[u8; 10] = b"0123456789";
+        let mut tmp = [0u8; 20];
+        let mut idx = tmp.len();
+        let mut m = i.unsigned_abs();
+        loop {
+            idx -= 1;
+            tmp[idx] = DIGITS[usize::try_from(m % 10).unwrap_or(0)];
+            m /= 10;
+            if m == 0 {
+                break;
+            }
+        }
+        if i < 0 {
+            self.buf.push(b'-');
+        }
+        self.buf.extend_from_slice(&tmp[idx..]);
+    }
+
+    pub fn write_pyint(&mut self, v: &Bound<'_, PyAny>) -> PyResult<()> {
+        if let Ok(i) = v.extract::<i64>() {
+            self.write_i64(i);
+        } else {
+            let s = v.str()?;
+            self.buf.extend_from_slice(s.to_str()?.as_bytes());
+        }
+        Ok(())
+    }
+
+    pub fn write_f64(&mut self, f: f64) {
+        if f.is_nan() {
+            self.buf.extend_from_slice(b"NaN");
+            return;
+        }
+        if f.is_infinite() {
+            self.buf
+                .extend_from_slice(if f < 0.0 { b"-Infinity" } else { b"Infinity" });
+            return;
+        }
+        unsafe {
+            let ptr = pyo3::ffi::PyOS_double_to_string(
+                f,
+                b'r'.cast_signed(),
+                0,
+                pyo3::ffi::Py_DTSF_ADD_DOT_0,
+                std::ptr::null_mut(),
+            );
+            if ptr.is_null() {
+                return;
+            }
+            let cstr = std::ffi::CStr::from_ptr(ptr);
+            self.buf.extend_from_slice(cstr.to_bytes());
+            pyo3::ffi::PyMem_Free(ptr.cast());
+        }
+    }
+
+    fn write_unicode_escape(&mut self, cp: u32) {
+        self.buf.extend_from_slice(b"\\u");
+        self.buf.push(HEX[((cp >> 12) & 0xf) as usize]);
+        self.buf.push(HEX[((cp >> 8) & 0xf) as usize]);
+        self.buf.push(HEX[((cp >> 4) & 0xf) as usize]);
+        self.buf.push(HEX[(cp & 0xf) as usize]);
+    }
+
+    pub fn write_str(&mut self, s: &str) {
+        self.buf.push(b'"');
+        for c in s.chars() {
+            match c {
+                '"' => self.buf.extend_from_slice(b"\\\""),
+                '\\' => self.buf.extend_from_slice(b"\\\\"),
+                '\n' => self.buf.extend_from_slice(b"\\n"),
+                '\r' => self.buf.extend_from_slice(b"\\r"),
+                '\t' => self.buf.extend_from_slice(b"\\t"),
+                '\u{08}' => self.buf.extend_from_slice(b"\\b"),
+                '\u{0c}' => self.buf.extend_from_slice(b"\\f"),
+                c if (c as u32) < 0x20 => self.write_unicode_escape(c as u32),
+                c if (c as u32) < 0x7f => self.buf.push(c as u8),
+                c => {
+                    let cp = c as u32;
+                    if cp <= 0xffff {
+                        self.write_unicode_escape(cp);
+                    } else {
+                        let v = cp - 0x10000;
+                        self.write_unicode_escape(0xd800 + (v >> 10));
+                        self.write_unicode_escape(0xdc00 + (v & 0x3ff));
+                    }
+                }
+            }
+        }
+        self.buf.push(b'"');
+    }
+
+    pub fn write_str_value(&mut self, v: &Bound<'_, PyString>) -> PyResult<()> {
+        self.write_str(v.to_str()?);
+        Ok(())
+    }
+}

--- a/src/json/writer.rs
+++ b/src/json/writer.rs
@@ -1,10 +1,16 @@
-use pyo3::prelude::*;
-use pyo3::types::PyString;
+use crate::error::SerializationError;
 
 const HEX: &[u8; 16] = b"0123456789abcdef";
 
+#[derive(Clone, Copy)]
+pub struct Frame {
+    mark: usize,
+    had_first: bool,
+}
+
 pub struct JsonWriter {
     buf: Vec<u8>,
+    first: bool,
 }
 
 impl Default for JsonWriter {
@@ -17,6 +23,7 @@ impl JsonWriter {
     pub fn new() -> Self {
         Self {
             buf: Vec::with_capacity(256),
+            first: true,
         }
     }
 
@@ -24,28 +31,116 @@ impl JsonWriter {
         self.buf
     }
 
-    pub const fn len(&self) -> usize {
-        self.buf.len()
+    fn pre(&mut self, key: Option<&str>) {
+        if !self.first {
+            self.buf.push(b',');
+        }
+        self.first = false;
+        if let Some(k) = key {
+            self.fmt_str(k);
+            self.buf.push(b':');
+        }
     }
 
-    pub fn truncate(&mut self, n: usize) {
-        self.buf.truncate(n);
-    }
-
-    pub fn push(&mut self, b: u8) {
-        self.buf.push(b);
-    }
-
-    pub fn write_null(&mut self) {
+    pub fn value_null(&mut self, key: Option<&str>) {
+        self.pre(key);
         self.buf.extend_from_slice(b"null");
     }
 
-    pub fn write_bool(&mut self, b: bool) {
+    pub fn value_bool(&mut self, key: Option<&str>, b: bool) {
+        self.pre(key);
         self.buf
             .extend_from_slice(if b { b"true" } else { b"false" });
     }
 
-    pub fn write_i64(&mut self, i: i64) {
+    pub fn value_i64(&mut self, key: Option<&str>, i: i64) {
+        self.pre(key);
+        self.fmt_i64(i);
+    }
+
+    pub fn value_number_str(&mut self, key: Option<&str>, digits: &str) {
+        self.pre(key);
+        self.buf.extend_from_slice(digits.as_bytes());
+    }
+
+    pub fn value_f64(&mut self, key: Option<&str>, f: f64) {
+        self.pre(key);
+        self.fmt_f64(f);
+    }
+
+    pub fn value_str(&mut self, key: Option<&str>, s: &str) {
+        self.pre(key);
+        self.fmt_str(s);
+    }
+
+    pub fn begin_object(&mut self, key: Option<&str>) -> Frame {
+        let mark = self.buf.len();
+        let had_first = self.first;
+        self.pre(key);
+        self.buf.push(b'{');
+        self.first = true;
+        Frame { mark, had_first }
+    }
+
+    pub fn end_object(&mut self) {
+        self.buf.push(b'}');
+        self.first = false;
+    }
+
+    pub fn begin_array(&mut self, key: Option<&str>) -> Frame {
+        let mark = self.buf.len();
+        let had_first = self.first;
+        self.pre(key);
+        self.buf.push(b'[');
+        self.first = true;
+        Frame { mark, had_first }
+    }
+
+    pub fn end_array(&mut self) {
+        self.buf.push(b']');
+        self.first = false;
+    }
+
+    pub fn rollback(&mut self, frame: Frame) {
+        self.buf.truncate(frame.mark);
+        self.first = frame.had_first;
+    }
+
+    pub fn object<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializationError>,
+    {
+        let frame = self.begin_object(key);
+        match body(self) {
+            Ok(()) => {
+                self.end_object();
+                Ok(())
+            }
+            Err(e) => {
+                self.rollback(frame);
+                Err(e)
+            }
+        }
+    }
+
+    pub fn array<F>(&mut self, key: Option<&str>, body: F) -> Result<(), SerializationError>
+    where
+        F: FnOnce(&mut Self) -> Result<(), SerializationError>,
+    {
+        let frame = self.begin_array(key);
+        match body(self) {
+            Ok(()) => {
+                self.end_array();
+                Ok(())
+            }
+            Err(e) => {
+                self.rollback(frame);
+                Err(e)
+            }
+        }
+    }
+
+    fn fmt_i64(&mut self, i: i64) {
         const DIGITS: &[u8; 10] = b"0123456789";
         let mut tmp = [0u8; 20];
         let mut idx = tmp.len();
@@ -64,17 +159,7 @@ impl JsonWriter {
         self.buf.extend_from_slice(&tmp[idx..]);
     }
 
-    pub fn write_pyint(&mut self, v: &Bound<'_, PyAny>) -> PyResult<()> {
-        if let Ok(i) = v.extract::<i64>() {
-            self.write_i64(i);
-        } else {
-            let s = v.str()?;
-            self.buf.extend_from_slice(s.to_str()?.as_bytes());
-        }
-        Ok(())
-    }
-
-    pub fn write_f64(&mut self, f: f64) {
+    fn fmt_f64(&mut self, f: f64) {
         if f.is_nan() {
             self.buf.extend_from_slice(b"NaN");
             return;
@@ -109,7 +194,7 @@ impl JsonWriter {
         self.buf.push(HEX[(cp & 0xf) as usize]);
     }
 
-    pub fn write_str(&mut self, s: &str) {
+    fn fmt_str(&mut self, s: &str) {
         self.buf.push(b'"');
         for c in s.chars() {
             match c {
@@ -135,10 +220,5 @@ impl JsonWriter {
             }
         }
         self.buf.push(b'"');
-    }
-
-    pub fn write_str_value(&mut self, v: &Bound<'_, PyString>) -> PyResult<()> {
-        self.write_str(v.to_str()?);
-        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod container_dump;
 mod container_load;
 mod error;
 mod fields;
+mod json;
 mod slots;
 mod utils;
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -222,6 +222,33 @@ class NukedSerializer(Serializer):
         return mr.nuked.load(cls, data_json, naming_case=naming_case, decimal_places=decimal_places)
 
 
+class NukedBytesSerializer(NukedSerializer):
+    __slots__ = ()
+
+    def dump[T](
+        self,
+        cls: type[T],
+        obj: T,
+        naming_case: mr.NamingCase | None = None,
+        none_value_handling: mr.NoneValueHandling | None = None,
+        decimal_places: int | None = mr.MISSING,
+        encoding: str = "utf-8",
+    ) -> bytes:
+        return mr.nuked.dump_to_bytes(
+            cls, obj, naming_case=naming_case, none_value_handling=none_value_handling, decimal_places=decimal_places
+        )
+
+    def load[T](
+        self,
+        cls: type[T],
+        data: bytes,
+        naming_case: mr.NamingCase | None = None,
+        decimal_places: int | None = mr.MISSING,
+        encoding: str = "utf-8",
+    ) -> T:
+        return mr.nuked.load_from_bytes(cls, data, naming_case=naming_case, decimal_places=decimal_places)
+
+
 class NukedMappingSerializer(NukedSerializer):
     __slots__ = ()
 
@@ -354,11 +381,12 @@ class NukedSchemaSerializer(Serializer):
     params=[
         MarshmallowSerializer(),
         NukedSerializer(),
+        NukedBytesSerializer(),
         NukedSchemaSerializer(),
         NukedMappingSerializer(),
         NukedMissingSentinelSerializer(),
     ],
-    ids=["marshmallow", "nuked", "nuked_schema", "nuked_mapping", "nuked_missing_sentinel"],
+    ids=["marshmallow", "nuked", "nuked_bytes", "nuked_schema", "nuked_mapping", "nuked_missing_sentinel"],
 )
 def impl(request: pytest.FixtureRequest) -> Serializer:
     return request.param

--- a/tests/api/test_bytes_parser.py
+++ b/tests/api/test_bytes_parser.py
@@ -1,0 +1,112 @@
+import dataclasses
+import json
+from typing import Any
+
+import marshmallow
+import pytest
+
+import marshmallow_recipe as mr
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class WithStr:
+    value: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class WithInt:
+    value: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class WithAny:
+    value: Any
+
+
+class TestBytesParserJsonLoadsParity:
+    @pytest.mark.parametrize(
+        "data",
+        [
+            rb'{"value":"a\tb\n\r\"c\\d\/e\b\f"}',
+            '{"value":"é—你"}'.encode(),
+            '{"value":"\U0001f600"}'.encode(),
+            '{"value":"café—你好"}'.encode(),
+            rb'{"value":""}',
+            rb'{  "value"  :  "spaced"  }',
+            b'{\n\t"value"\r:\n"ws"\n}',
+        ],
+    )
+    def test_string_escapes_and_unicode(self, data: bytes) -> None:
+        assert mr.nuked.load_from_bytes(WithStr, data) == mr.nuked.load(WithStr, json.loads(data))
+
+    @pytest.mark.parametrize(
+        "data", [b'{"value":42}', b'{"value":-7}', b'{"value":12345678901234567890123456789}', b'{"value":0}']
+    )
+    def test_numbers(self, data: bytes) -> None:
+        assert mr.nuked.load_from_bytes(WithInt, data) == mr.nuked.load(WithInt, json.loads(data))
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b'{"value":1.5}',
+            b'{"value":-0.0}',
+            b'{"value":1e10}',
+            b'{"value":1E-5}',
+            b'{"value":[1,2.5,null,true,false,"x"]}',
+            b'{"value":{"a":1,"b":[2,3]}}',
+        ],
+    )
+    def test_any_materializer_matches_json_loads(self, data: bytes) -> None:
+        assert mr.nuked.load_from_bytes(WithAny, data) == mr.nuked.load(WithAny, json.loads(data))
+
+    def test_duplicate_key_last_wins(self) -> None:
+        data = b'{"value":"first","value":"second"}'
+        assert mr.nuked.load_from_bytes(WithStr, data) == WithStr(value="second")
+        assert json.loads(data) == {"value": "second"}
+
+    def test_unknown_keys_ignored(self) -> None:
+        data = b'{"value":"v","extra":[1,2,{"q":null}],"more":"x"}'
+        assert mr.nuked.load_from_bytes(WithStr, data) == WithStr(value="v")
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            b'{"value":01}',
+            b'{"value":00}',
+            b'{"value":"a",}',
+            b'{"value":"a"',
+            b'{"value" "a"}',
+            b'{value:"a"}',
+            b'{"value":"a"}trailing',
+            b'{"value":}',
+            b"",
+            b'{"value":"unterminated}',
+        ],
+    )
+    def test_malformed_raises_validation_error(self, data: bytes) -> None:
+        with pytest.raises(marshmallow.ValidationError):
+            mr.nuked.load_from_bytes(WithStr, data)
+
+    def test_nesting_within_limit(self) -> None:
+        depth = 100
+        data = ('{"value":' + "[" * depth + "1" + "]" * depth + "}").encode()
+        assert mr.nuked.load_from_bytes(WithAny, data) == mr.nuked.load(WithAny, json.loads(data))
+
+    def test_nesting_exceeds_limit_raises(self) -> None:
+        depth = 5000
+        data = ('{"value":' + "[" * depth + "1" + "]" * depth + "}").encode()
+        with pytest.raises(marshmallow.ValidationError):
+            mr.nuked.load_from_bytes(WithAny, data)
+
+    def test_special_floats_rejected_by_float_field(self) -> None:
+        @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+        class WithFloat:
+            value: float
+
+        for data in (b'{"value":NaN}', b'{"value":Infinity}', b'{"value":-Infinity}'):
+            with pytest.raises(marshmallow.ValidationError):
+                mr.nuked.load_from_bytes(WithFloat, data)
+
+    def test_round_trip(self) -> None:
+        obj = WithStr(value='quote " backslash \\ slash / tab \t newline \n é 😀')
+        assert mr.nuked.load_from_bytes(WithStr, mr.nuked.dump_to_bytes(WithStr, obj)) == obj


### PR DESCRIPTION
## Summary

Adds bytes-level JSON support to `nuked` and structures the serializer around a single traversal.

- New `src/json` module: `Parser` (`load_from_bytes`), `JsonWriter` (`dump_to_bytes`), and a `DumpSink` trait so one dump traversal feeds both `PyDictSink` (→ Python object) and `JsonWriterSink` (→ JSON bytes). Nesting rides the Rust call stack via `open_object`/`open_array` closures — no heap stack.
- Reader and writer both centralise structure (braces, commas, depth) in one place per side via closures, mirroring `Parser::iter_object`/`iter_array`.

## Writer design (2nd commit)

`JsonWriter` is value-oriented rather than a raw byte buffer:

- Scalar writers take a `key` and self-handle separators; structure rides `begin_object`/`end_object`/`rollback` (sink) and `object`/`array` closures (`write_pyobject`).
- `Bound<PyAny>` → primitive extraction lives in the sink, so the writer no longer depends on pyo3 types; `push`/`len`/`truncate` are no longer public.
- The hand-rolled comma/brace framing in `write_pyobject` now reuses the same value API; the i64-or-bigint dispatch is shared via `write_pyint`.

No behavioural or byte-output change from the refactor.

## Tests

- `make lint` (ruff / pyright / `cargo fmt` / `cargo clippy` pedantic) and `make test` green: **12301 passed, 55 skipped**.
- The `nuked_bytes` serializer runs the whole dump suite through `dump_to_bytes`, asserting byte-for-byte parity with `json.dumps(separators=(",", ":"))` — including `TestAnyDump`'s nested list/dict cases that exercise `write_pyobject`.

## Follow-ups

- `CHANGELOG.md` entry to be added at release time (per-release sectioning; version is a maintainer decision).
- Opened as **draft** — in-flight feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
