### PR TITLE
Bump PyO3 to 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.99 (2026-06-24)
+
+* [Bump PyO3 to 0.29](https://github.com/anna-money/marshmallow-recipe/pull/308)
+
+
 ## v0.0.98 (2026-05-29)
 
 * **Breaking:** `mr.json_schema()` now renders `T | None` as nullable JSON Schema. `str | None` becomes `{"type": ["string", "null"]}`; `Nested | None` becomes `{"anyOf": [{"$ref": "#/$defs/Nested"}, {"type": "null"}]}`; nullable enums and `Literal` types include `null` in both the `type` list and the `enum` list. Previously the `None` branch was dropped, producing schemas that rejected `null` even though the Python type allowed it. `NoneValueHandling` does not affect schema rendering — it remains a serialization-only setting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "chrono",
  "libc",
@@ -156,18 +156,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -187,13 +187,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "_nuked"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module", "uuid", "chrono"] }
+pyo3 = { version = "0.29", features = ["extension-module", "uuid", "chrono"] }
 smallbitvec = "2.6"
 smallvec = "1.15"
 uuid = { version = "1.23" }


### PR DESCRIPTION
Bumps PyO3 `0.28.3 → 0.29.0`. **No source changes** — the full 0.29.0 changelog was reconciled against the code; no breaking change touches `_nuked`.

## Verification
- `cargo fmt --check` + `cargo clippy` (deny all+pedantic) clean
- 10307 passed / 43 skipped on marshmallow `2.20.5` and `3.x` (Python 3.12); CI matrix covers 3.13/3.14
- `ruff` + `pyright` clean
- Benchmarks: no regression (nuked decimal load/dump ~1.6 µs, dict ~1.2 µs, enum ~0.4 µs)

## Why it's safe
No 0.29 breaking item applies: no `From<Utf8Error>`, no `get_refcnt`, no subclassing / `PyClassInitializer`, no `PyCapsule` / `PyCFunction::new_closure` / `PyClassGuard`, no `PyDate::from_timestamp`, only public FFI, Linux+macOS wheels only.

## 0.29 features worth using
- **Free on upgrade:** `call`/`call1`/`call_method1` refcount-cycle elision ([pyo3#5941](https://github.com/PyO3/pyo3/pull/5941)) + redundant self-type-check removal ([pyo3#5930](https://github.com/PyO3/pyo3/pull/5930)) — these hit our `__new__` and Decimal `quantize` hot paths. Micro-opts, within benchmark noise.
- **Recommended follow-up (separate PR):** free-threaded `cp314t` wheels. Code is ~95% ready (all global state is `PyOnceLock`; no `GILProtected`/`Mutex`). Needs `#[pymodule(gil_used=false)]` + a slot-write audit + a 3.14t CI lane. Not via `abi3t` — direct slot-offset access precludes the stable ABI.
- **Not applicable:** `PyDict::set_default`, `PyErr::set_context`, `abi3t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)