### PR TITLE
Fix nuked dump of datetime with non-fixed tzinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.100 (2026-07-13)
+
+* [Fix nuked dump of datetime with non-fixed tzinfo (ZoneInfo)](https://github.com/anna-money/marshmallow-recipe/pull/309)
+
+
 ## v0.0.99 (2026-06-24)
 
 * [Bump PyO3 to 0.29](https://github.com/anna-money/marshmallow-recipe/pull/308)

--- a/src/fields/datetime.rs
+++ b/src/fields/datetime.rs
@@ -1,7 +1,12 @@
-use chrono::{DateTime, FixedOffset, NaiveDateTime};
+use chrono::{DateTime, Duration, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use pyo3::conversion::IntoPyObjectExt;
+use pyo3::exceptions::PyValueError;
+use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyDateTime, PyFloat, PyInt, PyString};
+use pyo3::types::{
+    PyBool, PyDateAccess, PyDateTime, PyFloat, PyInt, PyString, PyTimeAccess, PyTzInfo,
+    PyTzInfoAccess,
+};
 
 use crate::error::SerializationError;
 use crate::utils::display_to_py;
@@ -125,11 +130,40 @@ pub fn dump_to_py(
 }
 
 fn extract_datetime(value: &Bound<'_, PyAny>) -> PyResult<DateTime<FixedOffset>> {
-    if let Ok(dt) = value.extract::<DateTime<FixedOffset>>() {
-        return Ok(dt);
+    let dt = value.cast::<PyDateTime>()?;
+    let naive = extract_naive_datetime(dt)?;
+    let Some(tzinfo) = dt.get_tzinfo() else {
+        return Ok(naive.and_utc().fixed_offset());
+    };
+    if tzinfo.is(PyTzInfo::utc(dt.py())?) {
+        return Ok(naive.and_utc().fixed_offset());
     }
-    let naive: NaiveDateTime = value.extract()?;
-    Ok(naive.and_utc().fixed_offset())
+    let utcoffset = tzinfo.call_method1(intern!(dt.py(), "utcoffset"), (dt,))?;
+    if utcoffset.is_none() {
+        return Err(PyValueError::new_err("utcoffset is None"));
+    }
+    let delta: Duration = utcoffset.extract()?;
+    let offset = i32::try_from(delta.num_seconds())
+        .ok()
+        .and_then(FixedOffset::east_opt)
+        .ok_or_else(|| PyValueError::new_err("utcoffset is out of bounds"))?;
+    naive
+        .and_local_timezone(offset)
+        .single()
+        .ok_or_else(|| PyValueError::new_err("datetime is out of bounds"))
+}
+
+fn extract_naive_datetime(dt: &Bound<'_, PyDateTime>) -> PyResult<NaiveDateTime> {
+    let date = NaiveDate::from_ymd_opt(dt.get_year(), dt.get_month().into(), dt.get_day().into())
+        .ok_or_else(|| PyValueError::new_err("date is out of bounds"))?;
+    let time = NaiveTime::from_hms_micro_opt(
+        dt.get_hour().into(),
+        dt.get_minute().into(),
+        dt.get_second().into(),
+        dt.get_microsecond(),
+    )
+    .ok_or_else(|| PyValueError::new_err("time is out of bounds"))?;
+    Ok(NaiveDateTime::new(date, time))
 }
 
 #[allow(clippy::cast_precision_loss)]

--- a/tests/api/test_datetime.py
+++ b/tests/api/test_datetime.py
@@ -1,4 +1,5 @@
 import datetime
+import zoneinfo
 
 import marshmallow
 import pytest
@@ -28,6 +29,21 @@ from .conftest import (
     WithDatetimeValidation,
 )
 
+LONDON = zoneinfo.ZoneInfo("Europe/London")
+NEW_YORK = zoneinfo.ZoneInfo("America/New_York")
+KOLKATA = zoneinfo.ZoneInfo("Asia/Kolkata")
+
+
+class CustomTzInfo(datetime.tzinfo):
+    def utcoffset(self, dt: datetime.datetime | None) -> datetime.timedelta:
+        return datetime.timedelta(hours=2)
+
+    def dst(self, dt: datetime.datetime | None) -> datetime.timedelta | None:
+        return None
+
+    def tzname(self, dt: datetime.datetime | None) -> str | None:
+        return None
+
 
 class TestDatetimeDump:
     def test_value(self, impl: Serializer) -> None:
@@ -40,6 +56,102 @@ class TestDatetimeDump:
         result = impl.dump(ValueOf[datetime.datetime], obj)
         assert result == b'{"value":"2025-12-26T10:30:45.100000+00:00"}'
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(
+                datetime.datetime(2026, 7, 2, 14, 43, 18, tzinfo=LONDON),
+                b'{"value":"2026-07-02T14:43:18+01:00"}',
+                id="zoneinfo_london_summer",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 1, 15, 10, 30, 45, tzinfo=LONDON),
+                b'{"value":"2026-01-15T10:30:45+00:00"}',
+                id="zoneinfo_london_winter",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 7, 2, 14, 43, 18, 123456, tzinfo=LONDON),
+                b'{"value":"2026-07-02T14:43:18.123456+01:00"}',
+                id="zoneinfo_london_summer_microseconds",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 7, 2, 9, 43, 18, tzinfo=NEW_YORK),
+                b'{"value":"2026-07-02T09:43:18-04:00"}',
+                id="zoneinfo_new_york_summer",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 1, 15, 10, 30, 45, tzinfo=NEW_YORK),
+                b'{"value":"2026-01-15T10:30:45-05:00"}',
+                id="zoneinfo_new_york_winter",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 7, 2, 19, 13, 18, tzinfo=KOLKATA),
+                b'{"value":"2026-07-02T19:13:18+05:30"}',
+                id="zoneinfo_kolkata",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 7, 2, 13, 43, 18, tzinfo=zoneinfo.ZoneInfo("UTC")),
+                b'{"value":"2026-07-02T13:43:18+00:00"}',
+                id="zoneinfo_utc",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 1, 15, 10, 30, 45, tzinfo=datetime.timezone(datetime.timedelta(hours=-5))),
+                b'{"value":"2026-01-15T10:30:45-05:00"}',
+                id="negative_timezone_offset",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 7, 2, 14, 43, 18, tzinfo=CustomTzInfo()),
+                b'{"value":"2026-07-02T14:43:18+02:00"}',
+                id="custom_tzinfo",
+            ),
+            pytest.param(
+                datetime.datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=datetime.UTC),
+                b'{"value":"9999-12-31T23:59:59.999999+00:00"}',
+                id="max_datetime",
+            ),
+        ],
+    )
+    def test_tzinfo_variants(self, impl: Serializer, value: datetime.datetime, expected: bytes) -> None:
+        obj = ValueOf[datetime.datetime](value=value)
+        result = impl.dump(ValueOf[datetime.datetime], obj)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(
+                datetime.datetime(2026, 10, 25, 1, 30, tzinfo=LONDON),
+                b'{"value":"2026-10-25T01:30:00+01:00"}',
+                id="ambiguous_fold_0",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 10, 25, 1, 30, fold=1, tzinfo=LONDON),
+                b'{"value":"2026-10-25T01:30:00+00:00"}',
+                id="ambiguous_fold_1",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 3, 29, 1, 30, tzinfo=LONDON),
+                b'{"value":"2026-03-29T01:30:00+00:00"}',
+                id="skipped_fold_0",
+            ),
+            pytest.param(
+                datetime.datetime(2026, 3, 29, 1, 30, fold=1, tzinfo=LONDON),
+                b'{"value":"2026-03-29T01:30:00+01:00"}',
+                id="skipped_fold_1",
+            ),
+        ],
+    )
+    def test_zoneinfo_dst_transition(self, impl: Serializer, value: datetime.datetime, expected: bytes) -> None:
+        obj = ValueOf[datetime.datetime](value=value)
+        result = impl.dump(ValueOf[datetime.datetime], obj)
+        assert result == expected
+
+    def test_zoneinfo_round_trip(self, impl: Serializer) -> None:
+        dt = datetime.datetime(2026, 7, 2, 14, 43, 18, tzinfo=LONDON)
+        dumped = impl.dump(ValueOf[datetime.datetime], ValueOf[datetime.datetime](value=dt))
+        loaded = impl.load(ValueOf[datetime.datetime], dumped)
+        assert loaded == ValueOf[datetime.datetime](value=dt)
+
     def test_format_date_only(self, impl: Serializer) -> None:
         obj = WithDateTimeCustomFormat(scheduled_at=datetime.datetime(2024, 12, 25, 14, 30, 0, tzinfo=datetime.UTC))
         result = impl.dump(WithDateTimeCustomFormat, obj)
@@ -50,11 +162,30 @@ class TestDatetimeDump:
         result = impl.dump(WithDateTimeCustomFormatFull, obj)
         assert result == b'{"created_at":"2024-06-15 14:30:45"}'
 
-    def test_format_with_timezone(self, impl: Serializer) -> None:
-        tz = datetime.timezone(datetime.timedelta(hours=3))
-        obj = WithDateTimeCustomFormatTimezone(created_at=datetime.datetime(2024, 6, 15, 14, 30, 45, tzinfo=tz))
+    @pytest.mark.parametrize(
+        ("obj", "expected"),
+        [
+            pytest.param(
+                WithDateTimeCustomFormatTimezone(
+                    created_at=datetime.datetime(
+                        2024, 6, 15, 14, 30, 45, tzinfo=datetime.timezone(datetime.timedelta(hours=3))
+                    )
+                ),
+                b'{"created_at":"2024-06-15T14:30:45+0300"}',
+                id="timezone_offset",
+            ),
+            pytest.param(
+                WithDateTimeCustomFormatTimezone(created_at=datetime.datetime(2026, 7, 2, 14, 43, 18, tzinfo=LONDON)),
+                b'{"created_at":"2026-07-02T14:43:18+0100"}',
+                id="zoneinfo",
+            ),
+        ],
+    )
+    def test_format_with_timezone(
+        self, impl: Serializer, obj: WithDateTimeCustomFormatTimezone, expected: bytes
+    ) -> None:
         result = impl.dump(WithDateTimeCustomFormatTimezone, obj)
-        assert result == b'{"created_at":"2024-06-15T14:30:45+0300"}'
+        assert result == expected
 
     def test_optional_none(self, impl: Serializer) -> None:
         obj = OptionalValueOf[datetime.datetime](value=None)
@@ -350,6 +481,21 @@ class TestDatetimeDump:
                 ),
                 b'{"created_at":1718461845.123456}',
                 id="with_microseconds",
+            ),
+            pytest.param(
+                WithDateTimeFormatTimestamp(created_at=datetime.datetime(2026, 7, 2, 14, 43, 18, tzinfo=LONDON)),
+                b'{"created_at":1782999798.0}',
+                id="zoneinfo",
+            ),
+            pytest.param(
+                WithDateTimeFormatTimestamp(created_at=datetime.datetime(2026, 10, 25, 1, 30, tzinfo=LONDON)),
+                b'{"created_at":1792888200.0}',
+                id="zoneinfo_ambiguous_fold_0",
+            ),
+            pytest.param(
+                WithDateTimeFormatTimestamp(created_at=datetime.datetime(2026, 10, 25, 1, 30, fold=1, tzinfo=LONDON)),
+                b'{"created_at":1792891800.0}',
+                id="zoneinfo_ambiguous_fold_1",
             ),
         ],
     )


### PR DESCRIPTION
## Problem

`nuked.dump` raised `ValidationError: Not a valid datetime.` for any aware datetime whose tzinfo is not a fixed offset (`zoneinfo.ZoneInfo`, pytz, dateutil). All three formats (iso, timestamp, strftime) were affected — they share one extraction function. `mr.dump` handled the same values fine, breaking mr/nuked parity.

## Root cause

`extract_datetime` relied on PyO3's chrono conversion, which resolves the offset via `tzinfo.utcoffset(None)`. Instant-dependent zones (DST) return `None` without a concrete datetime, so extraction failed; the naive fallback rejects any tzinfo.

## Fix

Rewrite `extract_datetime`, bypassing the PyO3 conversion:

* naive → assume UTC (unchanged)
* UTC singleton → pointer-identity check, zero Python calls (previously one)
* any other tzinfo → one `tzinfo.utcoffset(dt)` call — instant-correct and fold-aware, exactly what CPython does inside `isoformat()`/`timestamp()`/`strftime()`

Output matches the pure-Python path byte for byte. Also fixes pytz/dateutil and custom tzinfo by construction.

ns/dump (4 datetime fields, best of 7):

| tzinfo | before | after |
|---|---|---|
| UTC | 1628 | 1556 |
| fixed offset | 1507 | 1532 |
| naive | 1493 | 1420 |

## Known limitation

For sub-minute offsets (historical zones pre-1972, e.g. `Africa/Monrovia` −00:44:30) chrono `%z`/`%:z` rounds to the whole minute while Python prints seconds. Pre-existing for fixed offsets with seconds; timestamp format unaffected.

## Tests

New parametrised dump cases across all impls: London summer/winter, negative offset (New York), +05:30 (Kolkata), `ZoneInfo("UTC")` (non-singleton), custom tzinfo subclass, `datetime.max`, DST fold (ambiguous and skipped times, iso + timestamp), strftime `%z` with ZoneInfo, round-trip. Full suite green on marshmallow 2.20.5 and 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)