### PR TITLE
fix: camelCase collection items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.101 (2026-08-03)
+
+* [Fix nuked crash on collection fields with `CAMEL_CASE` naming](https://github.com/anna-money/marshmallow-recipe/pull/310)
+
+
 ## v0.0.100 (2026-07-13)
 
 * [Fix nuked dump of datetime with non-fixed tzinfo (ZoneInfo)](https://github.com/anna-money/marshmallow-recipe/pull/309)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.0.101 (2026-08-03)
 
-* [Fix nuked crash on collection fields with `CAMEL_CASE` naming](https://github.com/anna-money/marshmallow-recipe/pull/310)
+* [Fix nuked crash on collection fields with `CAMEL_CASE` naming](https://github.com/anna-money/marshmallow-recipe/pull/311)
 
 
 ## v0.0.100 (2026-07-13)

--- a/python/marshmallow_recipe/nuked/__init__.py
+++ b/python/marshmallow_recipe/nuked/__init__.py
@@ -578,7 +578,7 @@ class _BuildContext:
                 origin = get_origin(field_type)
                 args = get_args(field_type)
 
-        if data_key is None and naming_case is not None:
+        if data_key is None and naming_case is not None and name:
             data_key = naming_case(name)
 
         slot_offset = try_get_slot_offset(cls, name) if cls else None

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -435,6 +435,12 @@ class Company:
 
 
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class WithNestedList:
+    display_name: str
+    home_addresses: list[Address]
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
 class WithOptional:
     required: str
     optional_int: int | None = None

--- a/tests/api/test_naming.py
+++ b/tests/api/test_naming.py
@@ -1,6 +1,6 @@
 import marshmallow_recipe as mr
 
-from .conftest import Address, Person, Serializer, WithCustomName, WithSnakeCase
+from .conftest import Address, Person, Serializer, WithCollections, WithCustomName, WithNestedList, WithSnakeCase
 
 
 class TestNamingDump:
@@ -26,6 +26,30 @@ class TestNamingDump:
         obj = Person(name="Test", age=25, address=Address(street="Main St", city="NYC", zip_code="10001"))
         result = impl.dump(Person, obj, naming_case=mr.CAMEL_CASE)
         expected = b'{"name":"Test","age":25,"address":{"street":"Main St","city":"NYC","zipCode":"10001"}}'
+        assert result == expected
+
+    def test_collections_camel_case(self, impl: Serializer) -> None:
+        obj = WithCollections(
+            list_int=[1, 2],
+            list_str=["a"],
+            dict_str_int={"key": 1},
+            set_str={"x"},
+            frozenset_int=frozenset([7]),
+            tuple_str=("t",),
+        )
+        result = impl.dump(WithCollections, obj, naming_case=mr.CAMEL_CASE)
+        expected = (
+            b'{"listInt":[1,2],"listStr":["a"],"dictStrInt":{"key":1},'
+            b'"setStr":["x"],"frozensetInt":[7],"tupleStr":["t"]}'
+        )
+        assert result == expected
+
+    def test_nested_list_camel_case(self, impl: Serializer) -> None:
+        obj = WithNestedList(
+            display_name="Team", home_addresses=[Address(street="Main St", city="NYC", zip_code="10001")]
+        )
+        result = impl.dump(WithNestedList, obj, naming_case=mr.CAMEL_CASE)
+        expected = b'{"displayName":"Team","homeAddresses":[{"street":"Main St","city":"NYC","zipCode":"10001"}]}'
         assert result == expected
 
     def test_custom_name(self, impl: Serializer) -> None:
@@ -54,6 +78,28 @@ class TestNamingLoad:
         data = b'{"FIRST_NAME":"Sarah","LAST_NAME":"Wilson","EMAIL_ADDRESS":"sarah@example.com"}'
         result = impl.load(WithSnakeCase, data, naming_case=mr.UPPER_SNAKE_CASE)
         assert result == WithSnakeCase(first_name="Sarah", last_name="Wilson", email_address="sarah@example.com")
+
+    def test_collections_camel_case(self, impl: Serializer) -> None:
+        data = (
+            b'{"listInt":[1,2],"listStr":["a"],"dictStrInt":{"key":1},'
+            b'"setStr":["x"],"frozensetInt":[7],"tupleStr":["t"]}'
+        )
+        result = impl.load(WithCollections, data, naming_case=mr.CAMEL_CASE)
+        assert result == WithCollections(
+            list_int=[1, 2],
+            list_str=["a"],
+            dict_str_int={"key": 1},
+            set_str={"x"},
+            frozenset_int=frozenset([7]),
+            tuple_str=("t",),
+        )
+
+    def test_nested_list_camel_case(self, impl: Serializer) -> None:
+        data = b'{"displayName":"Team","homeAddresses":[{"street":"Main St","city":"NYC","zipCode":"10001"}]}'
+        result = impl.load(WithNestedList, data, naming_case=mr.CAMEL_CASE)
+        assert result == WithNestedList(
+            display_name="Team", home_addresses=[Address(street="Main St", city="NYC", zip_code="10001")]
+        )
 
     def test_custom_name(self, impl: Serializer) -> None:
         data = b'{"id":456,"email":"user@example.com"}'


### PR DESCRIPTION
issue #312 

`nuked.load` / `nuked.dump` fails on nested collections (`list` / `tuple` / `set` / `frozenset`) and `naming_case=CAMEL_CASE`

**Example**:

```python
from dataclasses import dataclass
from typing import Annotated

import marshmallow_recipe as mr


@dataclass(frozen=True, slots=True, kw_only=True)
class NestedModel:
    field_no1: int
    field_no2: Annotated[int, mr.meta(name="fieldNo2")]


@dataclass(frozen=True, slots=True, kw_only=True)
class Model:
    nested_field: list[NestedModel]



def main():
    # load
    response = {
        'nestedField': [
            {
                'fieldNo1': 10,
                'fieldNo2': 20,
            },
        ],
    }
    a = mr.load(Model, response, naming_case=mr.CAMEL_CASE)        # ok
    b = mr.nuked.load(Model, response, naming_case=mr.CAMEL_CASE)  # fails
    print(a)
    print(b)

    # dump
    model = Model(
        nested_field=[
            NestedModel(
                field_no1=10,
                field_no2=10,
            ),
        ],
    )
    a = mr.dump(Model, model, naming_case=mr.CAMEL_CASE)        # ok
    b = mr.nuked.dump(Model, model, naming_case=mr.CAMEL_CASE)  # fails
    print(a)
    print(b)


if __name__ == "__main__":
    main()
```